### PR TITLE
Simplify expression

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -64,7 +64,7 @@ const app = Elm.Terminal.Main.init({
   flags: {
     args: process.argv.slice(2),
     currentDirectory: process.cwd(),
-    envVars: Object.keys(process.env).reduce((acc, key) => { acc.push([key, process.env[key]]); return acc }, []),
+    envVars: Object.entries(process.env),
     homedir: os.homedir(),
     progName: "guida"
   }


### PR DESCRIPTION
As far as I am aware, this does _precisely_ the same. Though I am unsure about any potential super-odd-js-quirks, that seem to happen at times. I am also unsure about how to test this rigurously.

If the result is not a standard JS array, [...Object.entries(xyz)] should yield one.

Here's an overview of the behaviour one can expect from `Object.entries`
<img width="499" alt="image" src="https://github.com/user-attachments/assets/ff8f3a64-79ac-420b-8278-546b1ef486c9" />
