### PR TITLE
Reached heap limit Allocation failed - JavaScript heap out of memory (rtfeldman/elm-css)

### DIFF
--- a/src/Compiler/Json/String.elm
+++ b/src/Compiler/Json/String.elm
@@ -132,7 +132,7 @@ writeChunksHelp ((P.Snippet { fptr }) as snippet) chunks acc =
                 chunks_
                 (case chunk of
                     Slice offset len ->
-                        acc ++ String.left len (String.dropLeft offset fptr)
+                        acc ++ String.slice offset (offset + len) fptr
 
                     Escape 'n' ->
                         acc ++ String.fromChar '\n'

--- a/src/Compiler/Parse/Primitives.elm
+++ b/src/Compiler/Parse/Primitives.elm
@@ -486,7 +486,7 @@ snippetDecoder =
     BD.map5
         (\fptr offset length offRow offCol ->
             Snippet
-                { fptr = fptr
+                { fptr = String.fromList (String.toList fptr)
                 , offset = offset
                 , length = length
                 , offRow = offRow

--- a/src/Compiler/Parse/Primitives.elm
+++ b/src/Compiler/Parse/Primitives.elm
@@ -486,14 +486,14 @@ snippetDecoder =
     BD.map5
         (\fptr offset length offRow offCol ->
             Snippet
-                { fptr = String.fromList (String.toList fptr)
+                { fptr = String.fromList fptr
                 , offset = offset
                 , length = length
                 , offRow = offRow
                 , offCol = offCol
                 }
         )
-        BD.string
+        (BD.map String.toList BD.string)
         BD.int
         BD.int
         BD.int


### PR DESCRIPTION
Relates to the discussion found here: https://discourse.elm-lang.org/t/there-are-3-elm-compilers-written-in-elm/10329/19

When trying to `guida make` the `rtfeldman/elm-css` package, we get a "Reached heap limit Allocation failed - JavaScript heap out of memory".

This branch is to review what are the underlying issues and the possible solutions.