### PR TITLE
Refactoring of Task aliases to make the approach to Tasks more unified accross the whole code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@ node_modules
 elm-stuff
 .DS_Store
 .idea
-elm-watch.json
-elm-watch-output.js
 
 # Guida
 guida-stuff
@@ -22,4 +20,3 @@ bin/guida.min.js
 
 # Try
 try/public/app.js
-

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules
 elm-stuff
 .DS_Store
 .idea
+elm-watch.json
+elm-watch-output.js
 
 # Guida
 guida-stuff
@@ -20,3 +22,4 @@ bin/guida.min.js
 
 # Try
 try/public/app.js
+

--- a/src/Browser/Install.elm
+++ b/src/Browser/Install.elm
@@ -33,7 +33,7 @@ run pkg =
                             Task.pure (Err Exit.InstallNoOutline)
 
                         Just root ->
-                            Task.toResult
+                            Task.run
                                 (Task.eio Exit.InstallBadRegistry Solver.initEnv
                                     |> Task.bind
                                         (\env ->

--- a/src/Browser/Install.elm
+++ b/src/Browser/Install.elm
@@ -7,7 +7,6 @@ import Builder.Elm.Details as Details
 import Builder.Elm.Outline as Outline
 import Builder.Reporting as Reporting
 import Builder.Reporting.Exit as Exit
-import Builder.Reporting.Task as WasRepTask
 import Builder.Stuff as Stuff
 import Compiler.Elm.Constraint as C
 import Compiler.Elm.Package as Pkg
@@ -16,6 +15,7 @@ import Data.Map as Dict exposing (Dict)
 import System.IO as IO
 import Task exposing (Task)
 import Utils.Main as Utils exposing (FilePath)
+import Utils.Task.Extra as TE
 
 
 
@@ -26,28 +26,28 @@ run : Pkg.Name -> Task Never ()
 run pkg =
     Reporting.attempt Exit.installToReport
         (Stuff.findRoot
-            |> IO.bind
+            |> TE.bind
                 (\maybeRoot ->
                     case maybeRoot of
                         Nothing ->
-                            IO.pure (Err Exit.InstallNoOutline)
+                            TE.pure (Err Exit.InstallNoOutline)
 
                         Just root ->
-                            WasRepTask.run
-                                (WasRepTask.eio Exit.InstallBadRegistry Solver.initEnv
-                                    |> WasRepTask.bind
+                            TE.toResult
+                                (TE.eio Exit.InstallBadRegistry Solver.initEnv
+                                    |> TE.bind
                                         (\env ->
-                                            WasRepTask.eio Exit.InstallBadOutline (Outline.read root)
-                                                |> WasRepTask.bind
+                                            TE.eio Exit.InstallBadOutline (Outline.read root)
+                                                |> TE.bind
                                                     (\oldOutline ->
                                                         case oldOutline of
                                                             Outline.App outline ->
                                                                 makeAppPlan env pkg outline
-                                                                    |> WasRepTask.bind (\changes -> attemptChanges root env oldOutline V.toChars changes)
+                                                                    |> TE.bind (\changes -> attemptChanges root env oldOutline V.toChars changes)
 
                                                             Outline.Pkg outline ->
                                                                 makePkgPlan env pkg outline
-                                                                    |> WasRepTask.bind (\changes -> attemptChanges root env oldOutline C.toChars changes)
+                                                                    |> TE.bind (\changes -> attemptChanges root env oldOutline C.toChars changes)
                                                     )
                                         )
                                 )
@@ -70,7 +70,7 @@ attemptChanges : String -> Solver.Env -> Outline.Outline -> (a -> String) -> Cha
 attemptChanges root env oldOutline _ changes =
     case changes of
         AlreadyInstalled ->
-            WasRepTask.io (IO.putStrLn "It is already installed!")
+            TE.io (IO.putStrLn "It is already installed!")
 
         PromoteIndirect newOutline ->
             attemptChangesHelp root env oldOutline newOutline
@@ -84,21 +84,21 @@ attemptChanges root env oldOutline _ changes =
 
 attemptChangesHelp : FilePath -> Solver.Env -> Outline.Outline -> Outline.Outline -> Task Exit.Install ()
 attemptChangesHelp root env oldOutline newOutline =
-    WasRepTask.eio Exit.InstallBadDetails <|
+    TE.eio Exit.InstallBadDetails <|
         BW.withScope
             (\scope ->
                 Outline.write root newOutline
-                    |> IO.bind (\_ -> Details.verifyInstall scope root env newOutline)
-                    |> IO.bind
+                    |> TE.bind (\_ -> Details.verifyInstall scope root env newOutline)
+                    |> TE.bind
                         (\result ->
                             case result of
                                 Err exit ->
                                     Outline.write root oldOutline
-                                        |> IO.fmap (\_ -> Err exit)
+                                        |> TE.fmap (\_ -> Err exit)
 
                                 Ok () ->
                                     IO.putStrLn "Success!"
-                                        |> IO.fmap (\_ -> Ok ())
+                                        |> TE.fmap (\_ -> Ok ())
                         )
             )
 
@@ -110,13 +110,13 @@ attemptChangesHelp root env oldOutline newOutline =
 makeAppPlan : Solver.Env -> Pkg.Name -> Outline.AppOutline -> Task Exit.Install (Changes V.Version)
 makeAppPlan (Solver.Env cache _ connection registry) pkg ((Outline.AppOutline elmVersion sourceDirs direct indirect testDirect testIndirect) as outline) =
     if Dict.member identity pkg direct then
-        WasRepTask.pure AlreadyInstalled
+        TE.pure AlreadyInstalled
 
     else
         -- is it already indirect?
         case Dict.get identity pkg indirect of
             Just vsn ->
-                WasRepTask.pure <|
+                TE.pure <|
                     PromoteIndirect <|
                         Outline.App <|
                             Outline.AppOutline elmVersion
@@ -130,7 +130,7 @@ makeAppPlan (Solver.Env cache _ connection registry) pkg ((Outline.AppOutline el
                 -- is it already a test dependency?
                 case Dict.get identity pkg testDirect of
                     Just vsn ->
-                        WasRepTask.pure <|
+                        TE.pure <|
                             PromoteTest <|
                                 Outline.App <|
                                     Outline.AppOutline elmVersion
@@ -144,7 +144,7 @@ makeAppPlan (Solver.Env cache _ connection registry) pkg ((Outline.AppOutline el
                         -- is it already an indirect test dependency?
                         case Dict.get identity pkg testIndirect of
                             Just vsn ->
-                                WasRepTask.pure <|
+                                TE.pure <|
                                     PromoteTest <|
                                         Outline.App <|
                                             Outline.AppOutline elmVersion
@@ -160,27 +160,27 @@ makeAppPlan (Solver.Env cache _ connection registry) pkg ((Outline.AppOutline el
                                     Err suggestions ->
                                         case connection of
                                             Solver.Online _ ->
-                                                WasRepTask.throw (Exit.InstallUnknownPackageOnline pkg suggestions)
+                                                TE.throw (Exit.InstallUnknownPackageOnline pkg suggestions)
 
                                             Solver.Offline ->
-                                                WasRepTask.throw (Exit.InstallUnknownPackageOffline pkg suggestions)
+                                                TE.throw (Exit.InstallUnknownPackageOffline pkg suggestions)
 
                                     Ok _ ->
-                                        WasRepTask.io (Solver.addToApp cache connection registry pkg outline False)
-                                            |> WasRepTask.bind
+                                        TE.io (Solver.addToApp cache connection registry pkg outline False)
+                                            |> TE.bind
                                                 (\result ->
                                                     case result of
                                                         Solver.SolverOk (Solver.AppSolution _ _ app) ->
-                                                            WasRepTask.pure (Changes (Outline.App app))
+                                                            TE.pure (Changes (Outline.App app))
 
                                                         Solver.NoSolution ->
-                                                            WasRepTask.throw (Exit.InstallNoOnlineAppSolution pkg)
+                                                            TE.throw (Exit.InstallNoOnlineAppSolution pkg)
 
                                                         Solver.NoOfflineSolution ->
-                                                            WasRepTask.throw (Exit.InstallNoOfflineAppSolution pkg)
+                                                            TE.throw (Exit.InstallNoOfflineAppSolution pkg)
 
                                                         Solver.SolverErr exit ->
-                                                            WasRepTask.throw (Exit.InstallHadSolverTrouble exit)
+                                                            TE.throw (Exit.InstallHadSolverTrouble exit)
                                                 )
 
 
@@ -191,13 +191,13 @@ makeAppPlan (Solver.Env cache _ connection registry) pkg ((Outline.AppOutline el
 makePkgPlan : Solver.Env -> Pkg.Name -> Outline.PkgOutline -> Task Exit.Install (Changes C.Constraint)
 makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline name summary license version exposed deps test elmVersion) =
     if Dict.member identity pkg deps then
-        WasRepTask.pure AlreadyInstalled
+        TE.pure AlreadyInstalled
 
     else
         -- is already in test dependencies?
         case Dict.get identity pkg test of
             Just con ->
-                WasRepTask.pure <|
+                TE.pure <|
                     PromoteTest <|
                         Outline.Pkg <|
                             Outline.PkgOutline name
@@ -215,10 +215,10 @@ makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline nam
                     Err suggestions ->
                         case connection of
                             Solver.Online _ ->
-                                WasRepTask.throw (Exit.InstallUnknownPackageOnline pkg suggestions)
+                                TE.throw (Exit.InstallUnknownPackageOnline pkg suggestions)
 
                             Solver.Offline ->
-                                WasRepTask.throw (Exit.InstallUnknownPackageOffline pkg suggestions)
+                                TE.throw (Exit.InstallUnknownPackageOffline pkg suggestions)
 
                     Ok (Registry.KnownVersions _ _) ->
                         let
@@ -230,8 +230,8 @@ makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline nam
                             cons =
                                 Dict.insert identity pkg C.anything old
                         in
-                        WasRepTask.io (Solver.verify cache connection registry cons)
-                            |> WasRepTask.bind
+                        TE.io (Solver.verify cache connection registry cons)
+                            |> TE.bind
                                 (\result ->
                                     case result of
                                         Solver.SolverOk solution ->
@@ -255,7 +255,7 @@ makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline nam
                                                 news =
                                                     Utils.mapMapMaybe identity Pkg.compareName keepNew changes
                                             in
-                                            WasRepTask.pure <|
+                                            TE.pure <|
                                                 Changes <|
                                                     Outline.Pkg <|
                                                         Outline.PkgOutline name
@@ -268,13 +268,13 @@ makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline nam
                                                             elmVersion
 
                                         Solver.NoSolution ->
-                                            WasRepTask.throw (Exit.InstallNoOnlinePkgSolution pkg)
+                                            TE.throw (Exit.InstallNoOnlinePkgSolution pkg)
 
                                         Solver.NoOfflineSolution ->
-                                            WasRepTask.throw (Exit.InstallNoOfflinePkgSolution pkg)
+                                            TE.throw (Exit.InstallNoOfflinePkgSolution pkg)
 
                                         Solver.SolverErr exit ->
-                                            WasRepTask.throw (Exit.InstallHadSolverTrouble exit)
+                                            TE.throw (Exit.InstallHadSolverTrouble exit)
                                 )
 
 

--- a/src/Browser/Main.elm
+++ b/src/Browser/Main.elm
@@ -10,7 +10,8 @@ import Compiler.Json.Encode as E
 import Compiler.Parse.Primitives as P
 import Json.Decode as Decode
 import Json.Encode as Encode
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Utils.Impure as Impure
 
 
@@ -19,7 +20,7 @@ main =
     IO.run app
 
 
-app : IO ()
+app : Task Never ()
 app =
     getArgs
         |> IO.bind
@@ -65,12 +66,12 @@ app =
             )
 
 
-getArgs : IO Args
+getArgs : Task Never Args
 getArgs =
     Impure.task "getArgs" [] Impure.EmptyBody (Impure.DecoderResolver argsDecoder)
 
 
-exitWithResponse : Encode.Value -> IO a
+exitWithResponse : Encode.Value -> Task Never a
 exitWithResponse value =
     Impure.task "exitWithResponse" [] (Impure.JsonBody value) Impure.Crash
 

--- a/src/Browser/Main.elm
+++ b/src/Browser/Main.elm
@@ -13,6 +13,7 @@ import Json.Encode as Encode
 import System.IO as IO
 import Task exposing (Task)
 import Utils.Impure as Impure
+import Utils.Task.Extra as TE
 
 
 main : IO.Program
@@ -23,12 +24,12 @@ main =
 app : Task Never ()
 app =
     getArgs
-        |> IO.bind
+        |> TE.bind
             (\args ->
                 case args of
                     MakeArgs path debug optimize withSourceMaps ->
                         Make.run path (Make.Flags debug optimize withSourceMaps)
-                            |> IO.bind
+                            |> TE.bind
                                 (\result ->
                                     case result of
                                         Ok output ->
@@ -50,7 +51,7 @@ app =
                         case P.fromByteString Pkg.parser Tuple.pair pkgString of
                             Ok pkg ->
                                 Install.run pkg
-                                    |> IO.bind (\_ -> exitWithResponse Encode.null)
+                                    |> TE.bind (\_ -> exitWithResponse Encode.null)
 
                             Err _ ->
                                 exitWithResponse (Encode.object [ ( "error", Encode.string "Invalid package..." ) ])
@@ -59,7 +60,7 @@ app =
                         case P.fromByteString Pkg.parser Tuple.pair pkgString of
                             Ok pkg ->
                                 Uninstall.run pkg
-                                    |> IO.bind (\_ -> exitWithResponse Encode.null)
+                                    |> TE.bind (\_ -> exitWithResponse Encode.null)
 
                             Err _ ->
                                 exitWithResponse (Encode.object [ ( "error", Encode.string "Invalid package..." ) ])

--- a/src/Browser/Main.elm
+++ b/src/Browser/Main.elm
@@ -13,7 +13,7 @@ import Json.Encode as Encode
 import System.IO as IO
 import Task exposing (Task)
 import Utils.Impure as Impure
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 main : IO.Program
@@ -24,12 +24,12 @@ main =
 app : Task Never ()
 app =
     getArgs
-        |> TE.bind
+        |> Task.bind
             (\args ->
                 case args of
                     MakeArgs path debug optimize withSourceMaps ->
                         Make.run path (Make.Flags debug optimize withSourceMaps)
-                            |> TE.bind
+                            |> Task.bind
                                 (\result ->
                                     case result of
                                         Ok output ->
@@ -51,7 +51,7 @@ app =
                         case P.fromByteString Pkg.parser Tuple.pair pkgString of
                             Ok pkg ->
                                 Install.run pkg
-                                    |> TE.bind (\_ -> exitWithResponse Encode.null)
+                                    |> Task.bind (\_ -> exitWithResponse Encode.null)
 
                             Err _ ->
                                 exitWithResponse (Encode.object [ ( "error", Encode.string "Invalid package..." ) ])
@@ -60,7 +60,7 @@ app =
                         case P.fromByteString Pkg.parser Tuple.pair pkgString of
                             Ok pkg ->
                                 Uninstall.run pkg
-                                    |> TE.bind (\_ -> exitWithResponse Encode.null)
+                                    |> Task.bind (\_ -> exitWithResponse Encode.null)
 
                             Err _ ->
                                 exitWithResponse (Encode.object [ ( "error", Encode.string "Invalid package..." ) ])

--- a/src/Browser/Make.elm
+++ b/src/Browser/Make.elm
@@ -17,14 +17,15 @@ import Builder.Elm.Details as Details
 import Builder.Generate as Generate
 import Builder.Reporting as Reporting
 import Builder.Reporting.Exit as Exit
-import Builder.Reporting.Task as Task
+import Builder.Reporting.Task as ReportingTask
 import Builder.Stuff as Stuff
 import Compiler.AST.Optimized as Opt
 import Compiler.Data.NonEmptyList as NE
 import Compiler.Elm.ModuleName as ModuleName
 import Compiler.Generate.Html as Html
 import Maybe.Extra as Maybe
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Terminal.Terminal.Internal exposing (Parser(..))
 import Utils.Crash exposing (crash)
 import Utils.Main as Utils exposing (FilePath)
@@ -52,11 +53,7 @@ type ReportType
 -- RUN
 
 
-type alias Task a =
-    Task.Task Exit.Make a
-
-
-run : String -> Flags -> IO (Result Exit.Make String)
+run : String -> Flags -> Task Never (Result Exit.Make String)
 run path flags =
     Stuff.findRoot
         |> IO.bind
@@ -70,34 +67,34 @@ run path flags =
             )
 
 
-runHelp : String -> String -> Flags -> IO (Result Exit.Make String)
+runHelp : String -> String -> Flags -> Task Never (Result Exit.Make String)
 runHelp root path (Flags debug optimize withSourceMaps) =
     BW.withScope
         (\scope ->
             Stuff.withRootLock root <|
-                Task.run <|
+                ReportingTask.run <|
                     (getMode debug optimize
-                        |> Task.bind
+                        |> ReportingTask.bind
                             (\desiredMode ->
                                 let
                                     style : Reporting.Style
                                     style =
                                         Reporting.json
                                 in
-                                Task.eio Exit.MakeBadDetails (Details.load style scope root)
-                                    |> Task.bind
+                                ReportingTask.eio Exit.MakeBadDetails (Details.load style scope root)
+                                    |> ReportingTask.bind
                                         (\details ->
                                             buildPaths style root details (NE.Nonempty path [])
-                                                |> Task.bind
+                                                |> ReportingTask.bind
                                                     (\artifacts ->
                                                         case getMains artifacts of
                                                             [] ->
-                                                                -- Task.pure ()
+                                                                -- ReportingTask.pure ()
                                                                 crash "No main!"
 
                                                             [ name ] ->
                                                                 toBuilder withSourceMaps Html.leadingLines root details desiredMode artifacts
-                                                                    |> Task.bind (Task.pure << Html.sandwich name)
+                                                                    |> ReportingTask.bind (ReportingTask.pure << Html.sandwich name)
 
                                                             _ ->
                                                                 crash "TODO"
@@ -112,29 +109,29 @@ runHelp root path (Flags debug optimize withSourceMaps) =
 -- GET INFORMATION
 
 
-getMode : Bool -> Bool -> Task DesiredMode
+getMode : Bool -> Bool -> Task Exit.Make DesiredMode
 getMode debug optimize =
     case ( debug, optimize ) of
         ( True, True ) ->
-            Task.throw Exit.MakeCannotOptimizeAndDebug
+            ReportingTask.throw Exit.MakeCannotOptimizeAndDebug
 
         ( True, False ) ->
-            Task.pure Debug
+            ReportingTask.pure Debug
 
         ( False, False ) ->
-            Task.pure Dev
+            ReportingTask.pure Dev
 
         ( False, True ) ->
-            Task.pure Prod
+            ReportingTask.pure Prod
 
 
 
 -- BUILD PROJECTS
 
 
-buildPaths : Reporting.Style -> FilePath -> Details.Details -> NE.Nonempty FilePath -> Task Build.Artifacts
+buildPaths : Reporting.Style -> FilePath -> Details.Details -> NE.Nonempty FilePath -> Task Exit.Make Build.Artifacts
 buildPaths style root details paths =
-    Task.eio Exit.MakeCannotBuild <|
+    ReportingTask.eio Exit.MakeCannotBuild <|
         Build.fromPaths style root details paths
 
 
@@ -182,9 +179,9 @@ type DesiredMode
     | Prod
 
 
-toBuilder : Bool -> Int -> FilePath -> Details.Details -> DesiredMode -> Build.Artifacts -> Task String
+toBuilder : Bool -> Int -> FilePath -> Details.Details -> DesiredMode -> Build.Artifacts -> Task Exit.Make String
 toBuilder withSourceMaps leadingLines root details desiredMode artifacts =
-    Task.mapError Exit.MakeBadGenerate <|
+    ReportingTask.mapError Exit.MakeBadGenerate <|
         case desiredMode of
             Debug ->
                 Generate.debug withSourceMaps leadingLines root details artifacts

--- a/src/Browser/Make.elm
+++ b/src/Browser/Make.elm
@@ -17,18 +17,17 @@ import Builder.Elm.Details as Details
 import Builder.Generate as Generate
 import Builder.Reporting as Reporting
 import Builder.Reporting.Exit as Exit
-import Utils.Task.Extra as TE
 import Builder.Stuff as Stuff
 import Compiler.AST.Optimized as Opt
 import Compiler.Data.NonEmptyList as NE
 import Compiler.Elm.ModuleName as ModuleName
 import Compiler.Generate.Html as Html
 import Maybe.Extra as Maybe
-import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Terminal.Terminal.Internal exposing (Parser(..))
 import Utils.Crash exposing (crash)
 import Utils.Main as Utils exposing (FilePath)
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Browser/Make.elm
+++ b/src/Browser/Make.elm
@@ -71,7 +71,7 @@ runHelp root path (Flags debug optimize withSourceMaps) =
     BW.withScope
         (\scope ->
             Stuff.withRootLock root <|
-                Task.toResult <|
+                Task.run <|
                     (getMode debug optimize
                         |> Task.bind
                             (\desiredMode ->

--- a/src/Browser/Uninstall.elm
+++ b/src/Browser/Uninstall.elm
@@ -32,7 +32,7 @@ run pkg =
                             Task.pure (Err Exit.UninstallNoOutline)
 
                         Just root ->
-                            Task.toResult
+                            Task.run
                                 (Task.eio Exit.UninstallBadRegistry Solver.initEnv
                                     |> Task.bind
                                         (\env ->

--- a/src/Builder/BackgroundWriter.elm
+++ b/src/Builder/BackgroundWriter.elm
@@ -5,7 +5,8 @@ module Builder.BackgroundWriter exposing
     )
 
 import Builder.File as File
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Main as Utils
@@ -19,7 +20,7 @@ type Scope
     = Scope (Utils.MVar (List (Utils.MVar ())))
 
 
-withScope : (Scope -> IO a) -> IO a
+withScope : (Scope -> Task Never a) -> Task Never a
 withScope callback =
     Utils.newMVar (BE.list (\_ -> BE.unit ())) []
         |> IO.bind
@@ -37,7 +38,7 @@ withScope callback =
             )
 
 
-writeBinary : (a -> BE.Encoder) -> Scope -> String -> a -> IO ()
+writeBinary : (a -> BE.Encoder) -> Scope -> String -> a -> Task Never ()
 writeBinary toEncoder (Scope workList) path value =
     Utils.newEmptyMVar
         |> IO.bind

--- a/src/Builder/BackgroundWriter.elm
+++ b/src/Builder/BackgroundWriter.elm
@@ -5,11 +5,11 @@ module Builder.BackgroundWriter exposing
     )
 
 import Builder.File as File
-import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Main as Utils
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Builder/Build.elm
+++ b/src/Builder/Build.elm
@@ -48,13 +48,13 @@ import Compiler.Reporting.Render.Type.Localizer as L
 import Data.Graph as Graph
 import Data.Map as Dict exposing (Dict)
 import Data.Set as EverySet
-import Utils.Task.Extra as TE
 import System.TypeCheck.IO as TypeCheck
 import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Crash exposing (crash)
 import Utils.Main as Utils exposing (FilePath, MVar(..))
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Builder/Deps/Diff.elm
+++ b/src/Builder/Deps/Diff.elm
@@ -25,9 +25,9 @@ import Compiler.Json.Decode as D
 import Data.Map as Dict exposing (Dict)
 import Data.Set as EverySet
 import List
-import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Utils.Main as Utils
+import Utils.Task.Extra as TE
 
 
 type PackageChanges

--- a/src/Builder/Deps/Diff.elm
+++ b/src/Builder/Deps/Diff.elm
@@ -25,7 +25,7 @@ import Compiler.Json.Decode as D
 import Data.Map as Dict exposing (Dict)
 import Data.Set as EverySet
 import List
-import System.IO as IO
+import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Utils.Main as Utils
 
@@ -408,34 +408,34 @@ getDocs cache manager name version =
             home ++ "/docs.json"
     in
     File.exists path
-        |> IO.bind
+        |> TE.bind
             (\exists ->
                 if exists then
                     File.readUtf8 path
-                        |> IO.bind
+                        |> TE.bind
                             (\bytes ->
                                 case D.fromByteString Docs.decoder bytes of
                                     Ok docs ->
-                                        IO.pure (Ok docs)
+                                        TE.pure (Ok docs)
 
                                     Err _ ->
                                         File.remove path
-                                            |> IO.fmap (\_ -> Err DP_Cache)
+                                            |> TE.fmap (\_ -> Err DP_Cache)
                             )
 
                 else
                     Website.metadata name version "docs.json"
-                        |> IO.bind
+                        |> TE.bind
                             (\url ->
                                 Http.get manager url [] Exit.DP_Http <|
                                     \body ->
                                         case D.fromByteString Docs.decoder body of
                                             Ok docs ->
                                                 Utils.dirCreateDirectoryIfMissing True home
-                                                    |> IO.bind (\_ -> File.writeUtf8 path body)
-                                                    |> IO.fmap (\_ -> Ok docs)
+                                                    |> TE.bind (\_ -> File.writeUtf8 path body)
+                                                    |> TE.fmap (\_ -> Ok docs)
 
                                             Err _ ->
-                                                IO.pure (Err (DP_Data url body))
+                                                TE.pure (Err (DP_Data url body))
                             )
             )

--- a/src/Builder/Deps/Diff.elm
+++ b/src/Builder/Deps/Diff.elm
@@ -27,7 +27,7 @@ import Data.Set as EverySet
 import List
 import Task exposing (Task)
 import Utils.Main as Utils
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 type PackageChanges
@@ -408,34 +408,34 @@ getDocs cache manager name version =
             home ++ "/docs.json"
     in
     File.exists path
-        |> TE.bind
+        |> Task.bind
             (\exists ->
                 if exists then
                     File.readUtf8 path
-                        |> TE.bind
+                        |> Task.bind
                             (\bytes ->
                                 case D.fromByteString Docs.decoder bytes of
                                     Ok docs ->
-                                        TE.pure (Ok docs)
+                                        Task.pure (Ok docs)
 
                                     Err _ ->
                                         File.remove path
-                                            |> TE.fmap (\_ -> Err DP_Cache)
+                                            |> Task.fmap (\_ -> Err DP_Cache)
                             )
 
                 else
                     Website.metadata name version "docs.json"
-                        |> TE.bind
+                        |> Task.bind
                             (\url ->
                                 Http.get manager url [] Exit.DP_Http <|
                                     \body ->
                                         case D.fromByteString Docs.decoder body of
                                             Ok docs ->
                                                 Utils.dirCreateDirectoryIfMissing True home
-                                                    |> TE.bind (\_ -> File.writeUtf8 path body)
-                                                    |> TE.fmap (\_ -> Ok docs)
+                                                    |> Task.bind (\_ -> File.writeUtf8 path body)
+                                                    |> Task.fmap (\_ -> Ok docs)
 
                                             Err _ ->
-                                                TE.pure (Err (DP_Data url body))
+                                                Task.pure (Err (DP_Data url body))
                             )
             )

--- a/src/Builder/Deps/Diff.elm
+++ b/src/Builder/Deps/Diff.elm
@@ -25,7 +25,8 @@ import Compiler.Json.Decode as D
 import Data.Map as Dict exposing (Dict)
 import Data.Set as EverySet
 import List
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Utils.Main as Utils
 
 
@@ -395,7 +396,7 @@ changeMagnitude (Changes added changed removed) =
 -- GET DOCS
 
 
-getDocs : Stuff.PackageCache -> Http.Manager -> Pkg.Name -> V.Version -> IO (Result Exit.DocsProblem Docs.Documentation)
+getDocs : Stuff.PackageCache -> Http.Manager -> Pkg.Name -> V.Version -> Task Never (Result Exit.DocsProblem Docs.Documentation)
 getDocs cache manager name version =
     let
         home : String

--- a/src/Builder/Deps/Registry.elm
+++ b/src/Builder/Deps/Registry.elm
@@ -22,10 +22,10 @@ import Compiler.Elm.Version as V
 import Compiler.Json.Decode as D
 import Compiler.Parse.Primitives as P
 import Data.Map as Dict exposing (Dict)
-import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Builder/Deps/Registry.elm
+++ b/src/Builder/Deps/Registry.elm
@@ -25,7 +25,7 @@ import Data.Map as Dict exposing (Dict)
 import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 
@@ -71,7 +71,7 @@ fetch manager cache =
                     Stuff.registry cache
             in
             File.writeBinary registryEncoder path registry
-                |> TE.fmap (\_ -> registry)
+                |> Task.fmap (\_ -> registry)
 
 
 addEntry : KnownVersions -> Int -> Int
@@ -112,7 +112,7 @@ update manager cache ((Registry size packages) as oldRegistry) =
         \news ->
             case news of
                 [] ->
-                    TE.pure oldRegistry
+                    Task.pure oldRegistry
 
                 _ :: _ ->
                     let
@@ -129,7 +129,7 @@ update manager cache ((Registry size packages) as oldRegistry) =
                             Registry newSize newPkgs
                     in
                     File.writeBinary registryEncoder (Stuff.registry cache) newRegistry
-                        |> TE.fmap (\_ -> newRegistry)
+                        |> Task.fmap (\_ -> newRegistry)
 
 
 addNew : ( Pkg.Name, V.Version ) -> Dict ( String, String ) Pkg.Name KnownVersions -> Dict ( String, String ) Pkg.Name KnownVersions
@@ -179,7 +179,7 @@ bail _ _ =
 latest : Http.Manager -> Stuff.PackageCache -> Task Never (Result Exit.RegistryProblem Registry)
 latest manager cache =
     read cache
-        |> TE.bind
+        |> Task.bind
             (\maybeOldRegistry ->
                 case maybeOldRegistry of
                     Just oldRegistry ->
@@ -216,16 +216,16 @@ getVersions_ name (Registry _ versions) =
 post : Http.Manager -> String -> D.Decoder x a -> (a -> Task Never b) -> Task Never (Result Exit.RegistryProblem b)
 post manager path decoder callback =
     Website.route path []
-        |> TE.bind
+        |> Task.bind
             (\url ->
                 Http.post manager url [] Exit.RP_Http <|
                     \body ->
                         case D.fromByteString decoder body of
                             Ok a ->
-                                TE.fmap Ok (callback a)
+                                Task.fmap Ok (callback a)
 
                             Err _ ->
-                                TE.pure <| Err <| Exit.RP_Data url body
+                                Task.pure <| Err <| Exit.RP_Data url body
             )
 
 

--- a/src/Builder/Deps/Solver.elm
+++ b/src/Builder/Deps/Solver.elm
@@ -27,12 +27,12 @@ import Compiler.Elm.Package as Pkg
 import Compiler.Elm.Version as V
 import Compiler.Json.Decode as D
 import Data.Map as Dict exposing (Dict)
-import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Crash exposing (crash)
 import Utils.Main as Utils
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Builder/Deps/Website.elm
+++ b/src/Builder/Deps/Website.elm
@@ -6,23 +6,24 @@ module Builder.Deps.Website exposing
 import Builder.Http as Http
 import Compiler.Elm.Package as Pkg
 import Compiler.Elm.Version as V
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Utils.Main as Utils
 
 
-domain : IO String
+domain : Task Never String
 domain =
     Utils.envLookupEnv "GUIDA_REGISTRY"
         |> IO.fmap (Maybe.withDefault "https://package.elm-lang.org")
 
 
-route : String -> List ( String, String ) -> IO String
+route : String -> List ( String, String ) -> Task Never String
 route path params =
     domain
         |> IO.fmap (\d -> Http.toUrl (d ++ path) params)
 
 
-metadata : Pkg.Name -> V.Version -> String -> IO String
+metadata : Pkg.Name -> V.Version -> String -> Task Never String
 metadata name version file =
     domain
         |> IO.fmap (\d -> d ++ "/packages/" ++ Pkg.toUrl name ++ "/" ++ V.toChars version ++ "/" ++ file)

--- a/src/Builder/Deps/Website.elm
+++ b/src/Builder/Deps/Website.elm
@@ -6,9 +6,9 @@ module Builder.Deps.Website exposing
 import Builder.Http as Http
 import Compiler.Elm.Package as Pkg
 import Compiler.Elm.Version as V
-import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Utils.Main as Utils
+import Utils.Task.Extra as TE
 
 
 domain : Task Never String

--- a/src/Builder/Deps/Website.elm
+++ b/src/Builder/Deps/Website.elm
@@ -6,7 +6,7 @@ module Builder.Deps.Website exposing
 import Builder.Http as Http
 import Compiler.Elm.Package as Pkg
 import Compiler.Elm.Version as V
-import System.IO as IO
+import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Utils.Main as Utils
 
@@ -14,16 +14,16 @@ import Utils.Main as Utils
 domain : Task Never String
 domain =
     Utils.envLookupEnv "GUIDA_REGISTRY"
-        |> IO.fmap (Maybe.withDefault "https://package.elm-lang.org")
+        |> TE.fmap (Maybe.withDefault "https://package.elm-lang.org")
 
 
 route : String -> List ( String, String ) -> Task Never String
 route path params =
     domain
-        |> IO.fmap (\d -> Http.toUrl (d ++ path) params)
+        |> TE.fmap (\d -> Http.toUrl (d ++ path) params)
 
 
 metadata : Pkg.Name -> V.Version -> String -> Task Never String
 metadata name version file =
     domain
-        |> IO.fmap (\d -> d ++ "/packages/" ++ Pkg.toUrl name ++ "/" ++ V.toChars version ++ "/" ++ file)
+        |> TE.fmap (\d -> d ++ "/packages/" ++ Pkg.toUrl name ++ "/" ++ V.toChars version ++ "/" ++ file)

--- a/src/Builder/Deps/Website.elm
+++ b/src/Builder/Deps/Website.elm
@@ -8,22 +8,22 @@ import Compiler.Elm.Package as Pkg
 import Compiler.Elm.Version as V
 import Task exposing (Task)
 import Utils.Main as Utils
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 domain : Task Never String
 domain =
     Utils.envLookupEnv "GUIDA_REGISTRY"
-        |> TE.fmap (Maybe.withDefault "https://package.elm-lang.org")
+        |> Task.fmap (Maybe.withDefault "https://package.elm-lang.org")
 
 
 route : String -> List ( String, String ) -> Task Never String
 route path params =
     domain
-        |> TE.fmap (\d -> Http.toUrl (d ++ path) params)
+        |> Task.fmap (\d -> Http.toUrl (d ++ path) params)
 
 
 metadata : Pkg.Name -> V.Version -> String -> Task Never String
 metadata name version file =
     domain
-        |> TE.fmap (\d -> d ++ "/packages/" ++ Pkg.toUrl name ++ "/" ++ V.toChars version ++ "/" ++ file)
+        |> Task.fmap (\d -> d ++ "/packages/" ++ Pkg.toUrl name ++ "/" ++ V.toChars version ++ "/" ++ file)

--- a/src/Builder/Elm/Details.elm
+++ b/src/Builder/Elm/Details.elm
@@ -150,10 +150,10 @@ verifyInstall scope root (Solver.Env cache manager connection registry) outline 
                 in
                 case outline of
                     Outline.Pkg pkg ->
-                        Task.toResult (Task.fmap (\_ -> ()) (verifyPkg env time pkg))
+                        Task.run (Task.fmap (\_ -> ()) (verifyPkg env time pkg))
 
                     Outline.App app ->
-                        Task.toResult (Task.fmap (\_ -> ()) (verifyApp env time app))
+                        Task.run (Task.fmap (\_ -> ()) (verifyApp env time app))
             )
 
 
@@ -201,10 +201,10 @@ generate style scope root time =
                             Ok ( env, outline ) ->
                                 case outline of
                                     Outline.Pkg pkg ->
-                                        Task.toResult (verifyPkg env time pkg)
+                                        Task.run (verifyPkg env time pkg)
 
                                     Outline.App app ->
-                                        Task.toResult (verifyApp env time app)
+                                        Task.run (verifyApp env time app)
                     )
         )
 

--- a/src/Builder/Elm/Details.elm
+++ b/src/Builder/Elm/Details.elm
@@ -25,7 +25,6 @@ import Builder.File as File
 import Builder.Http as Http
 import Builder.Reporting as Reporting
 import Builder.Reporting.Exit as Exit
-import Utils.Task.Extra as TE
 import Builder.Stuff as Stuff
 import Compiler.AST.Canonical as Can
 import Compiler.AST.Optimized as Opt
@@ -48,13 +47,13 @@ import Compiler.Parse.SyntaxVersion as SV exposing (SyntaxVersion)
 import Compiler.Reporting.Annotation as A
 import Data.Map as Dict exposing (Dict)
 import Data.Set as EverySet exposing (EverySet)
-import Utils.Task.Extra as TE
 import System.TypeCheck.IO as TypeCheck
 import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Crash exposing (crash)
 import Utils.Main as Utils exposing (FilePath, MVar)
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Builder/Elm/Outline.elm
+++ b/src/Builder/Elm/Outline.elm
@@ -31,12 +31,12 @@ import Compiler.Json.Decode as D
 import Compiler.Json.Encode as E
 import Compiler.Parse.Primitives as P
 import Data.Map as Dict exposing (Dict)
-import Utils.Task.Extra as TE
 import System.TypeCheck.IO as TypeCheck
 import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Main as Utils exposing (FilePath)
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Builder/Elm/Outline.elm
+++ b/src/Builder/Elm/Outline.elm
@@ -36,7 +36,7 @@ import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Main as Utils exposing (FilePath)
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 
@@ -175,16 +175,16 @@ encodeSrcDir srcDir =
 read : FilePath -> Task Never (Result Exit.Outline Outline)
 read root =
     File.readUtf8 (root ++ "/elm.json")
-        |> TE.bind
+        |> Task.bind
             (\bytes ->
                 case D.fromByteString decoder bytes of
                     Err err ->
-                        TE.pure <| Err (Exit.OutlineHasBadStructure err)
+                        Task.pure <| Err (Exit.OutlineHasBadStructure err)
 
                     Ok outline ->
                         case outline of
                             Pkg (PkgOutline pkg _ _ _ _ deps _ _) ->
-                                TE.pure <|
+                                Task.pure <|
                                     if not (Dict.member identity Pkg.core deps) && pkg /= Pkg.core then
                                         Err Exit.OutlineNoPkgCore
 
@@ -193,29 +193,29 @@ read root =
 
                             App (AppOutline _ srcDirs direct indirect _ _) ->
                                 if not (Dict.member identity Pkg.core direct) then
-                                    TE.pure <| Err Exit.OutlineNoAppCore
+                                    Task.pure <| Err Exit.OutlineNoAppCore
 
                                 else if not (Dict.member identity Pkg.json direct) && not (Dict.member identity Pkg.json indirect) then
-                                    TE.pure <| Err Exit.OutlineNoAppJson
+                                    Task.pure <| Err Exit.OutlineNoAppJson
 
                                 else
                                     Utils.filterM (isSrcDirMissing root) (NE.toList srcDirs)
-                                        |> TE.bind
+                                        |> Task.bind
                                             (\badDirs ->
                                                 case List.map toGiven badDirs of
                                                     d :: ds ->
-                                                        TE.pure <| Err (Exit.OutlineHasMissingSrcDirs d ds)
+                                                        Task.pure <| Err (Exit.OutlineHasMissingSrcDirs d ds)
 
                                                     [] ->
                                                         detectDuplicates root (NE.toList srcDirs)
-                                                            |> TE.bind
+                                                            |> Task.bind
                                                                 (\maybeDups ->
                                                                     case maybeDups of
                                                                         Nothing ->
-                                                                            TE.pure <| Ok outline
+                                                                            Task.pure <| Ok outline
 
                                                                         Just ( canonicalDir, ( dir1, dir2 ) ) ->
-                                                                            TE.pure <| Err (Exit.OutlineHasDuplicateSrcDirs canonicalDir dir1 dir2)
+                                                                            Task.pure <| Err (Exit.OutlineHasDuplicateSrcDirs canonicalDir dir1 dir2)
                                                                 )
                                             )
             )
@@ -223,7 +223,7 @@ read root =
 
 isSrcDirMissing : FilePath -> SrcDir -> Task Never Bool
 isSrcDirMissing root srcDir =
-    TE.fmap not (Utils.dirDoesDirectoryExist (toAbsolute root srcDir))
+    Task.fmap not (Utils.dirDoesDirectoryExist (toAbsolute root srcDir))
 
 
 toGiven : SrcDir -> FilePath
@@ -249,7 +249,7 @@ toAbsolute root srcDir =
 detectDuplicates : FilePath -> List SrcDir -> Task Never (Maybe ( FilePath, ( FilePath, FilePath ) ))
 detectDuplicates root srcDirs =
     Utils.listTraverse (toPair root) srcDirs
-        |> TE.fmap
+        |> Task.fmap
             (\pairs ->
                 Utils.mapLookupMin <|
                     Utils.mapMapMaybe identity compare isDup <|
@@ -260,9 +260,9 @@ detectDuplicates root srcDirs =
 toPair : FilePath -> SrcDir -> Task Never ( FilePath, OneOrMore.OneOrMore FilePath )
 toPair root srcDir =
     Utils.dirCanonicalizePath (toAbsolute root srcDir)
-        |> TE.bind
+        |> Task.bind
             (\key ->
-                TE.pure ( key, OneOrMore.one (toGiven srcDir) )
+                Task.pure ( key, OneOrMore.one (toGiven srcDir) )
             )
 
 
@@ -283,11 +283,11 @@ isDup paths =
 getAllModulePaths : FilePath -> Task Never (Dict (List String) TypeCheck.Canonical FilePath)
 getAllModulePaths root =
     read root
-        |> TE.bind
+        |> Task.bind
             (\outlineResult ->
                 case outlineResult of
                     Err _ ->
-                        TE.pure Dict.empty
+                        Task.pure Dict.empty
 
                     Ok outline ->
                         case outline of
@@ -316,13 +316,13 @@ getAllModulePaths root =
 getAllModulePathsHelper : Pkg.Name -> List FilePath -> Dict ( String, String ) Pkg.Name V.Version -> Task Never (Dict (List String) TypeCheck.Canonical FilePath)
 getAllModulePathsHelper packageName packageSrcDirs deps =
     Utils.listTraverse recursiveFindFiles packageSrcDirs
-        |> TE.bind
+        |> Task.bind
             (\files ->
                 Utils.mapTraverseWithKey identity compare resolvePackagePaths deps
-                    |> TE.bind
+                    |> Task.bind
                         (\dependencyRoots ->
                             Utils.mapTraverse identity compare (\( pkgName, pkgRoot ) -> getAllModulePathsHelper pkgName [ pkgRoot ++ "/src" ] Dict.empty) dependencyRoots
-                                |> TE.fmap
+                                |> Task.fmap
                                     (\dependencyMaps ->
                                         let
                                             asMap : Dict (List String) TypeCheck.Canonical FilePath
@@ -340,13 +340,13 @@ getAllModulePathsHelper packageName packageSrcDirs deps =
 recursiveFindFiles : FilePath -> Task Never (List ( FilePath, FilePath ))
 recursiveFindFiles root =
     recursiveFindFilesHelp root
-        |> TE.fmap (List.map (Tuple.pair root))
+        |> Task.fmap (List.map (Tuple.pair root))
 
 
 recursiveFindFilesHelp : FilePath -> Task Never (List FilePath)
 recursiveFindFilesHelp root =
     Utils.dirListDirectory root
-        |> TE.bind
+        |> Task.bind
             (\dirContents ->
                 let
                     ( elmFiles, ( guidaFiles, others ) ) =
@@ -354,10 +354,10 @@ recursiveFindFilesHelp root =
                             |> Tuple.mapSecond (List.partition (hasExtension ".guida"))
                 in
                 Utils.filterM (\fp -> Utils.dirDoesDirectoryExist (root ++ "/" ++ fp)) others
-                    |> TE.bind
+                    |> Task.bind
                         (\subDirectories ->
                             Utils.listTraverse (\subDirectory -> recursiveFindFilesHelp (root ++ "/" ++ subDirectory)) subDirectories
-                                |> TE.fmap
+                                |> Task.fmap
                                     (\filesFromSubDirs ->
                                         List.concat filesFromSubDirs ++ List.map (\fp -> root ++ "/" ++ fp) (elmFiles ++ guidaFiles)
                                     )
@@ -381,7 +381,7 @@ moduleNameFromFilePath root filePath =
 resolvePackagePaths : Pkg.Name -> V.Version -> Task Never ( Pkg.Name, FilePath )
 resolvePackagePaths pkgName vsn =
     Stuff.getPackageCache
-        |> TE.fmap (\packageCache -> ( pkgName, Stuff.package packageCache pkgName vsn ))
+        |> Task.fmap (\packageCache -> ( pkgName, Stuff.package packageCache pkgName vsn ))
 
 
 

--- a/src/Builder/File.elm
+++ b/src/Builder/File.elm
@@ -22,7 +22,7 @@ import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Impure as Impure
 import Utils.Main as Utils exposing (FilePath)
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 
@@ -35,7 +35,7 @@ type Time
 
 getTime : FilePath -> Task Never Time
 getTime path =
-    TE.fmap Time (Utils.dirGetModificationTime path)
+    Task.fmap Time (Utils.dirGetModificationTime path)
 
 
 zeroTime : Time
@@ -55,21 +55,21 @@ writeBinary toEncoder path value =
             Utils.fpDropFileName path
     in
     Utils.dirCreateDirectoryIfMissing True dir
-        |> TE.bind (\_ -> Utils.binaryEncodeFile toEncoder path value)
+        |> Task.bind (\_ -> Utils.binaryEncodeFile toEncoder path value)
 
 
 readBinary : BD.Decoder a -> FilePath -> Task Never (Maybe a)
 readBinary decoder path =
     Utils.dirDoesFileExist path
-        |> TE.bind
+        |> Task.bind
             (\pathExists ->
                 if pathExists then
                     Utils.binaryDecodeFileOrFail decoder path
-                        |> TE.bind
+                        |> Task.bind
                             (\result ->
                                 case result of
                                     Ok a ->
-                                        TE.pure (Just a)
+                                        Task.pure (Just a)
 
                                     Err ( offset, message ) ->
                                         IO.hPutStrLn IO.stderr
@@ -84,11 +84,11 @@ readBinary decoder path =
                                                 , "+-------------------------------------------------------------------------------"
                                                 ]
                                             )
-                                            |> TE.fmap (\_ -> Nothing)
+                                            |> Task.fmap (\_ -> Nothing)
                             )
 
                 else
-                    TE.pure Nothing
+                    Task.pure Nothing
             )
 
 
@@ -123,7 +123,7 @@ writePackage : FilePath -> Zip.Archive -> Task Never ()
 writePackage destination archive =
     case Zip.zEntries archive of
         [] ->
-            TE.pure ()
+            Task.pure ()
 
         entry :: entries ->
             let
@@ -154,7 +154,7 @@ writeEntry destination root entry =
             writeUtf8 (Utils.fpCombine destination path) (Zip.fromEntry entry)
 
     else
-        TE.pure ()
+        Task.pure ()
 
 
 
@@ -173,13 +173,13 @@ exists path =
 remove : FilePath -> Task Never ()
 remove path =
     Utils.dirDoesFileExist path
-        |> TE.bind
+        |> Task.bind
             (\exists_ ->
                 if exists_ then
                     Utils.dirRemoveFile path
 
                 else
-                    TE.pure ()
+                    Task.pure ()
             )
 
 

--- a/src/Builder/Generate.elm
+++ b/src/Builder/Generate.elm
@@ -10,7 +10,6 @@ import Builder.Elm.Details as Details
 import Builder.Elm.Outline as Outline
 import Builder.File as File
 import Builder.Reporting.Exit as Exit
-import Utils.Task.Extra as TE
 import Builder.Stuff as Stuff
 import Compiler.AST.Optimized as Opt
 import Compiler.Data.Name as N
@@ -23,11 +22,11 @@ import Compiler.Generate.JavaScript as JS
 import Compiler.Generate.Mode as Mode
 import Compiler.Nitpick.Debug as Nitpick
 import Data.Map as Dict exposing (Dict)
-import Utils.Task.Extra as TE
 import System.TypeCheck.IO as TypeCheck
 import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Main as Utils exposing (FilePath, MVar)
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Builder/Http.elm
+++ b/src/Builder/Http.elm
@@ -27,13 +27,13 @@ import Compiler.Elm.Version as V
 import Http
 import Json.Decode as Decode
 import Json.Encode as Encode
-import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Url.Builder
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Impure as Impure
 import Utils.Main as Utils exposing (SomeException)
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Builder/Http.elm
+++ b/src/Builder/Http.elm
@@ -33,7 +33,7 @@ import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Impure as Impure
 import Utils.Main as Utils exposing (SomeException)
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 
@@ -66,7 +66,7 @@ managerDecoder =
 getManager : Task Never Manager
 getManager =
     -- TODO newManager tlsManagerSettings
-    TE.pure Manager
+    Task.pure Manager
 
 
 

--- a/src/Builder/Http.elm
+++ b/src/Builder/Http.elm
@@ -27,8 +27,8 @@ import Compiler.Elm.Version as V
 import Http
 import Json.Decode as Decode
 import Json.Encode as Encode
-import System.IO as IO exposing (IO)
-import Task
+import System.IO as IO
+import Task exposing (Task)
 import Url.Builder
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
@@ -63,7 +63,7 @@ managerDecoder =
             )
 
 
-getManager : IO Manager
+getManager : Task Never Manager
 getManager =
     -- TODO newManager tlsManagerSettings
     IO.pure Manager
@@ -97,17 +97,17 @@ type alias Header =
     ( String, String )
 
 
-get : Manager -> String -> List Header -> (Error -> e) -> (String -> IO (Result e a)) -> IO (Result e a)
+get : Manager -> String -> List Header -> (Error -> e) -> (String -> Task Never (Result e a)) -> Task Never (Result e a)
 get =
     fetch "GET"
 
 
-post : Manager -> String -> List Header -> (Error -> e) -> (String -> IO (Result e a)) -> IO (Result e a)
+post : Manager -> String -> List Header -> (Error -> e) -> (String -> Task Never (Result e a)) -> Task Never (Result e a)
 post =
     fetch "POST"
 
 
-fetch : String -> Manager -> String -> List Header -> (Error -> e) -> (String -> IO (Result e a)) -> IO (Result e a)
+fetch : String -> Manager -> String -> List Header -> (Error -> e) -> (String -> Task Never (Result e a)) -> Task Never (Result e a)
 fetch method _ url headers _ onSuccess =
     Impure.customTask method
         url
@@ -159,7 +159,7 @@ shaToChars =
 -- FETCH ARCHIVE
 
 
-getArchive : Manager -> String -> (Error -> e) -> e -> (( Sha, Zip.Archive ) -> IO (Result e a)) -> IO (Result e a)
+getArchive : Manager -> String -> (Error -> e) -> e -> (( Sha, Zip.Archive ) -> Task Never (Result e a)) -> Task Never (Result e a)
 getArchive _ url _ _ onSuccess =
     Impure.task "getArchive"
         []
@@ -190,7 +190,7 @@ type MultiPart
     | StringPart String String
 
 
-upload : Manager -> String -> List MultiPart -> IO (Result Error ())
+upload : Manager -> String -> List MultiPart -> Task Never (Result Error ())
 upload _ url parts =
     Impure.task "httpUpload"
         []

--- a/src/Builder/Http.elm
+++ b/src/Builder/Http.elm
@@ -27,7 +27,7 @@ import Compiler.Elm.Version as V
 import Http
 import Json.Decode as Decode
 import Json.Encode as Encode
-import System.IO as IO
+import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Url.Builder
 import Utils.Bytes.Decode as BD
@@ -66,7 +66,7 @@ managerDecoder =
 getManager : Task Never Manager
 getManager =
     -- TODO newManager tlsManagerSettings
-    IO.pure Manager
+    TE.pure Manager
 
 
 

--- a/src/Builder/Reporting/Exit.elm
+++ b/src/Builder/Reporting/Exit.elm
@@ -61,7 +61,6 @@ import Compiler.Reporting.Error.Import as Import
 import Compiler.Reporting.Error.Json as Json
 import Compiler.Reporting.Render.Code as Code
 import Data.Map as Dict exposing (Dict)
-import System.IO
 import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE

--- a/src/Builder/Reporting/Exit.elm
+++ b/src/Builder/Reporting/Exit.elm
@@ -61,7 +61,8 @@ import Compiler.Reporting.Error.Import as Import
 import Compiler.Reporting.Error.Json as Json
 import Compiler.Reporting.Render.Code as Code
 import Data.Map as Dict exposing (Dict)
-import System.IO exposing (IO)
+import System.IO
+import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Main as Utils exposing (FilePath)
@@ -71,7 +72,7 @@ import Utils.Main as Utils exposing (FilePath)
 -- RENDERERS
 
 
-toStderr : Help.Report -> IO ()
+toStderr : Help.Report -> Task Never ()
 toStderr report =
     Help.toStderr (Help.reportToDoc report)
 

--- a/src/Builder/Reporting/Exit/Help.elm
+++ b/src/Builder/Reporting/Exit/Help.elm
@@ -16,7 +16,7 @@ import Compiler.Reporting.Error as Error
 import Maybe.Extra as Maybe
 import System.IO as IO
 import Task exposing (Task)
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 
@@ -130,7 +130,7 @@ toStderr doc =
 toHandle : IO.Handle -> D.Doc -> Task Never ()
 toHandle handle doc =
     IO.hIsTerminalDevice handle
-        |> TE.bind
+        |> Task.bind
             (\isTerminal ->
                 if isTerminal then
                     D.toAnsi handle doc

--- a/src/Builder/Reporting/Exit/Help.elm
+++ b/src/Builder/Reporting/Exit/Help.elm
@@ -16,6 +16,7 @@ import Compiler.Reporting.Error as Error
 import Maybe.Extra as Maybe
 import System.IO as IO
 import Task exposing (Task)
+import Utils.Task.Extra as TE
 
 
 
@@ -129,7 +130,7 @@ toStderr doc =
 toHandle : IO.Handle -> D.Doc -> Task Never ()
 toHandle handle doc =
     IO.hIsTerminalDevice handle
-        |> IO.bind
+        |> TE.bind
             (\isTerminal ->
                 if isTerminal then
                     D.toAnsi handle doc

--- a/src/Builder/Reporting/Exit/Help.elm
+++ b/src/Builder/Reporting/Exit/Help.elm
@@ -14,7 +14,8 @@ import Compiler.Json.Encode as E
 import Compiler.Reporting.Doc as D
 import Compiler.Reporting.Error as Error
 import Maybe.Extra as Maybe
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 
 
 
@@ -115,17 +116,17 @@ toString =
     D.toString
 
 
-toStdout : D.Doc -> IO ()
+toStdout : D.Doc -> Task Never ()
 toStdout doc =
     toHandle IO.stdout doc
 
 
-toStderr : D.Doc -> IO ()
+toStderr : D.Doc -> Task Never ()
 toStderr doc =
     toHandle IO.stderr doc
 
 
-toHandle : IO.Handle -> D.Doc -> IO ()
+toHandle : IO.Handle -> D.Doc -> Task Never ()
 toHandle handle doc =
     IO.hIsTerminalDevice handle
         |> IO.bind

--- a/src/Builder/Stuff.elm
+++ b/src/Builder/Stuff.elm
@@ -27,7 +27,7 @@ import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Main as Utils
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 
@@ -95,7 +95,7 @@ toArtifactPath root name ext =
 findRoot : Task Never (Maybe String)
 findRoot =
     Utils.dirGetCurrentDirectory
-        |> TE.bind
+        |> Task.bind
             (\dir ->
                 findRootHelp (Utils.fpSplitDirectories dir)
             )
@@ -105,14 +105,14 @@ findRootHelp : List String -> Task Never (Maybe String)
 findRootHelp dirs =
     case dirs of
         [] ->
-            TE.pure Nothing
+            Task.pure Nothing
 
         _ :: _ ->
             Utils.dirDoesFileExist (Utils.fpJoinPath dirs ++ "/elm.json")
-                |> TE.bind
+                |> Task.bind
                     (\exists ->
                         if exists then
-                            TE.pure (Just (Utils.fpJoinPath dirs))
+                            Task.pure (Just (Utils.fpJoinPath dirs))
 
                         else
                             findRootHelp (Prelude.init dirs)
@@ -131,7 +131,7 @@ withRootLock root work =
             stuff root
     in
     Utils.dirCreateDirectoryIfMissing True dir
-        |> TE.bind
+        |> Task.bind
             (\_ ->
                 Utils.lockWithFileLock (dir ++ "/lock") Utils.LockExclusive (\_ -> work)
             )
@@ -152,7 +152,7 @@ type PackageCache
 
 getPackageCache : Task Never PackageCache
 getPackageCache =
-    TE.fmap PackageCache (getCacheDir "packages")
+    Task.fmap PackageCache (getCacheDir "packages")
 
 
 registry : PackageCache -> String
@@ -177,7 +177,7 @@ getReplCache =
 getCacheDir : String -> Task Never String
 getCacheDir projectName =
     getElmHome
-        |> TE.bind
+        |> Task.bind
             (\home ->
                 let
                     root : Utils.FilePath
@@ -185,18 +185,18 @@ getCacheDir projectName =
                         Utils.fpCombine home (Utils.fpCombine compilerVersion projectName)
                 in
                 Utils.dirCreateDirectoryIfMissing True root
-                    |> TE.fmap (\_ -> root)
+                    |> Task.fmap (\_ -> root)
             )
 
 
 getElmHome : Task Never String
 getElmHome =
     Utils.envLookupEnv "GUIDA_HOME"
-        |> TE.bind
+        |> Task.bind
             (\maybeCustomHome ->
                 case maybeCustomHome of
                     Just customHome ->
-                        TE.pure customHome
+                        Task.pure customHome
 
                     Nothing ->
                         Utils.dirGetAppUserDataDirectory "guida"

--- a/src/Builder/Stuff.elm
+++ b/src/Builder/Stuff.elm
@@ -23,7 +23,8 @@ import Compiler.Elm.ModuleName as ModuleName
 import Compiler.Elm.Package as Pkg
 import Compiler.Elm.Version as V
 import Prelude
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Main as Utils
@@ -91,7 +92,7 @@ toArtifactPath root name ext =
 -- ROOT
 
 
-findRoot : IO (Maybe String)
+findRoot : Task Never (Maybe String)
 findRoot =
     Utils.dirGetCurrentDirectory
         |> IO.bind
@@ -100,7 +101,7 @@ findRoot =
             )
 
 
-findRootHelp : List String -> IO (Maybe String)
+findRootHelp : List String -> Task Never (Maybe String)
 findRootHelp dirs =
     case dirs of
         [] ->
@@ -122,7 +123,7 @@ findRootHelp dirs =
 -- LOCKS
 
 
-withRootLock : String -> IO a -> IO a
+withRootLock : String -> Task Never a -> Task Never a
 withRootLock root work =
     let
         dir : String
@@ -136,7 +137,7 @@ withRootLock root work =
             )
 
 
-withRegistryLock : PackageCache -> IO a -> IO a
+withRegistryLock : PackageCache -> Task Never a -> Task Never a
 withRegistryLock (PackageCache dir) work =
     Utils.lockWithFileLock (dir ++ "/lock") Utils.LockExclusive (\_ -> work)
 
@@ -149,7 +150,7 @@ type PackageCache
     = PackageCache String
 
 
-getPackageCache : IO PackageCache
+getPackageCache : Task Never PackageCache
 getPackageCache =
     IO.fmap PackageCache (getCacheDir "packages")
 
@@ -168,12 +169,12 @@ package (PackageCache dir) name version =
 -- CACHE
 
 
-getReplCache : IO String
+getReplCache : Task Never String
 getReplCache =
     getCacheDir "repl"
 
 
-getCacheDir : String -> IO String
+getCacheDir : String -> Task Never String
 getCacheDir projectName =
     getElmHome
         |> IO.bind
@@ -188,7 +189,7 @@ getCacheDir projectName =
             )
 
 
-getElmHome : IO String
+getElmHome : Task Never String
 getElmHome =
     Utils.envLookupEnv "GUIDA_HOME"
         |> IO.bind

--- a/src/Builder/Stuff.elm
+++ b/src/Builder/Stuff.elm
@@ -23,11 +23,11 @@ import Compiler.Elm.ModuleName as ModuleName
 import Compiler.Elm.Package as Pkg
 import Compiler.Elm.Version as V
 import Prelude
-import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Main as Utils
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Compiler/Compile.elm
+++ b/src/Compiler/Compile.elm
@@ -19,7 +19,7 @@ import Compiler.Reporting.Result as R
 import Compiler.Type.Constrain.Module as Type
 import Compiler.Type.Solve as Type
 import Data.Map exposing (Dict)
-import System.IO as IO
+import Utils.Task.Extra as TE
 import System.TypeCheck.IO as TypeCheck
 import Task exposing (Task)
 
@@ -34,8 +34,8 @@ type Artifacts
 
 compile : Pkg.Name -> Dict String ModuleName.Raw I.Interface -> Src.Module -> Task Never (Result E.Error Artifacts)
 compile pkg ifaces modul =
-    IO.pure (canonicalize pkg ifaces modul)
-        |> IO.fmap
+    TE.pure (canonicalize pkg ifaces modul)
+        |> TE.fmap
             (\canonicalResult ->
                 case canonicalResult of
                     Ok canonical ->

--- a/src/Compiler/Compile.elm
+++ b/src/Compiler/Compile.elm
@@ -21,7 +21,7 @@ import Compiler.Type.Solve as Type
 import Data.Map exposing (Dict)
 import System.TypeCheck.IO as TypeCheck
 import Task exposing (Task)
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 
@@ -34,8 +34,8 @@ type Artifacts
 
 compile : Pkg.Name -> Dict String ModuleName.Raw I.Interface -> Src.Module -> Task Never (Result E.Error Artifacts)
 compile pkg ifaces modul =
-    TE.pure (canonicalize pkg ifaces modul)
-        |> TE.fmap
+    Task.pure (canonicalize pkg ifaces modul)
+        |> Task.fmap
             (\canonicalResult ->
                 case canonicalResult of
                     Ok canonical ->

--- a/src/Compiler/Compile.elm
+++ b/src/Compiler/Compile.elm
@@ -19,9 +19,9 @@ import Compiler.Reporting.Result as R
 import Compiler.Type.Constrain.Module as Type
 import Compiler.Type.Solve as Type
 import Data.Map exposing (Dict)
-import Utils.Task.Extra as TE
 import System.TypeCheck.IO as TypeCheck
 import Task exposing (Task)
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Compiler/Compile.elm
+++ b/src/Compiler/Compile.elm
@@ -19,8 +19,9 @@ import Compiler.Reporting.Result as R
 import Compiler.Type.Constrain.Module as Type
 import Compiler.Type.Solve as Type
 import Data.Map exposing (Dict)
-import System.IO as IO exposing (IO)
+import System.IO as IO
 import System.TypeCheck.IO as TypeCheck
+import Task exposing (Task)
 
 
 
@@ -31,7 +32,7 @@ type Artifacts
     = Artifacts Can.Module (Dict String Name Can.Annotation) Opt.LocalGraph
 
 
-compile : Pkg.Name -> Dict String ModuleName.Raw I.Interface -> Src.Module -> IO (Result E.Error Artifacts)
+compile : Pkg.Name -> Dict String ModuleName.Raw I.Interface -> Src.Module -> Task Never (Result E.Error Artifacts)
 compile pkg ifaces modul =
     IO.pure (canonicalize pkg ifaces modul)
         |> IO.fmap

--- a/src/Compiler/Data/Map/Utils.elm
+++ b/src/Compiler/Data/Map/Utils.elm
@@ -5,9 +5,9 @@ module Compiler.Data.Map.Utils exposing
     )
 
 import Data.Map as Dict exposing (Dict)
-import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Utils.Main as Utils
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Compiler/Data/Map/Utils.elm
+++ b/src/Compiler/Data/Map/Utils.elm
@@ -5,7 +5,8 @@ module Compiler.Data.Map.Utils exposing
     )
 
 import Data.Map as Dict exposing (Dict)
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Utils.Main as Utils
 
 
@@ -18,7 +19,7 @@ fromKeys toValue keys =
     Dict.fromList identity (List.map (\k -> ( k, toValue k )) keys)
 
 
-fromKeysA : (k -> comparable) -> (k -> IO v) -> List k -> IO (Dict comparable k v)
+fromKeysA : (k -> comparable) -> (k -> Task Never v) -> List k -> Task Never (Dict comparable k v)
 fromKeysA toComparable toValue keys =
     IO.fmap (Dict.fromList toComparable) (Utils.listTraverse (\k -> IO.fmap (Tuple.pair k) (toValue k)) keys)
 

--- a/src/Compiler/Data/Map/Utils.elm
+++ b/src/Compiler/Data/Map/Utils.elm
@@ -5,7 +5,7 @@ module Compiler.Data.Map.Utils exposing
     )
 
 import Data.Map as Dict exposing (Dict)
-import System.IO as IO
+import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Utils.Main as Utils
 
@@ -21,7 +21,7 @@ fromKeys toValue keys =
 
 fromKeysA : (k -> comparable) -> (k -> Task Never v) -> List k -> Task Never (Dict comparable k v)
 fromKeysA toComparable toValue keys =
-    IO.fmap (Dict.fromList toComparable) (Utils.listTraverse (\k -> IO.fmap (Tuple.pair k) (toValue k)) keys)
+    TE.fmap (Dict.fromList toComparable) (Utils.listTraverse (\k -> TE.fmap (Tuple.pair k) (toValue k)) keys)
 
 
 

--- a/src/Compiler/Data/Map/Utils.elm
+++ b/src/Compiler/Data/Map/Utils.elm
@@ -7,7 +7,7 @@ module Compiler.Data.Map.Utils exposing
 import Data.Map as Dict exposing (Dict)
 import Task exposing (Task)
 import Utils.Main as Utils
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 
@@ -21,7 +21,7 @@ fromKeys toValue keys =
 
 fromKeysA : (k -> comparable) -> (k -> Task Never v) -> List k -> Task Never (Dict comparable k v)
 fromKeysA toComparable toValue keys =
-    TE.fmap (Dict.fromList toComparable) (Utils.listTraverse (\k -> TE.fmap (Tuple.pair k) (toValue k)) keys)
+    Task.fmap (Dict.fromList toComparable) (Utils.listTraverse (\k -> Task.fmap (Tuple.pair k) (toValue k)) keys)
 
 
 

--- a/src/Compiler/Json/Encode.elm
+++ b/src/Compiler/Json/Encode.elm
@@ -29,7 +29,8 @@ import Compiler.Data.OneOrMore exposing (OneOrMore(..))
 import Data.Map as Dict exposing (Dict)
 import Data.Set as EverySet exposing (EverySet)
 import Json.Encode as Encode
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 
 
 
@@ -207,19 +208,19 @@ escape chrs =
 -- WRITE TO FILE
 
 
-write : String -> Value -> IO ()
+write : String -> Value -> Task Never ()
 write path value =
     fileWriteBuilder path (encode value ++ "\n")
 
 
-writeUgly : String -> Value -> IO ()
+writeUgly : String -> Value -> Task Never ()
 writeUgly path value =
     fileWriteBuilder path (encodeUgly value)
 
 
 {-| FIXME Builder.File.writeBuilder
 -}
-fileWriteBuilder : String -> String -> IO ()
+fileWriteBuilder : String -> String -> Task Never ()
 fileWriteBuilder =
     IO.writeString
 

--- a/src/Compiler/Reporting/Doc.elm
+++ b/src/Compiler/Reporting/Doc.elm
@@ -42,7 +42,8 @@ import Compiler.Json.Encode as E
 import Maybe.Extra as Maybe
 import Prelude
 import System.Console.Ansi as Ansi
-import System.IO exposing (Handle, IO)
+import System.IO exposing (Handle)
+import Task exposing (Task)
 import Text.PrettyPrint.ANSI.Leijen as P
 
 
@@ -79,7 +80,7 @@ fromInt n =
 -- TO STRING
 
 
-toAnsi : Handle -> Doc -> IO ()
+toAnsi : Handle -> Doc -> Task Never ()
 toAnsi handle doc =
     P.displayIO handle (P.renderPretty 1 80 doc)
 

--- a/src/Control/Monad/State/Strict.elm
+++ b/src/Control/Monad/State/Strict.elm
@@ -15,7 +15,7 @@ import Json.Encode as Encode
 import System.IO as IO
 import Task exposing (Task)
 import Utils.Impure as Impure
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 {-| newtype StateT s m a
@@ -36,12 +36,12 @@ type StateT s a
 
 evalStateT : StateT s a -> s -> Task Never a
 evalStateT (StateT f) =
-    f >> TE.fmap Tuple.first
+    f >> Task.fmap Tuple.first
 
 
 liftIO : Task Never a -> StateT s a
 liftIO io =
-    StateT (\s -> TE.fmap (\a -> ( a, s )) io)
+    StateT (\s -> Task.fmap (\a -> ( a, s )) io)
 
 
 apply : StateT s a -> StateT s (a -> b) -> StateT s b
@@ -49,10 +49,10 @@ apply (StateT arg) (StateT func) =
     StateT
         (\s ->
             arg s
-                |> TE.bind
+                |> Task.bind
                     (\( a, sa ) ->
                         func sa
-                            |> TE.fmap (\( fb, sb ) -> ( fb a, sb ))
+                            |> Task.fmap (\( fb, sb ) -> ( fb a, sb ))
                     )
         )
 
@@ -64,7 +64,7 @@ fmap func argStateT =
 
 pure : a -> StateT s a
 pure value =
-    StateT (\s -> TE.pure ( value, s ))
+    StateT (\s -> Task.pure ( value, s ))
 
 
 get : StateT s IO.ReplState

--- a/src/Control/Monad/State/Strict.elm
+++ b/src/Control/Monad/State/Strict.elm
@@ -12,7 +12,8 @@ module Control.Monad.State.Strict exposing
 
 import Json.Decode as Decode
 import Json.Encode as Encode
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Utils.Impure as Impure
 
 
@@ -29,15 +30,15 @@ Ref.: <https://hackage.haskell.org/package/transformers-0.6.1.2/docs/Control-Mon
 
 -}
 type StateT s a
-    = StateT (s -> IO ( a, s ))
+    = StateT (s -> Task Never ( a, s ))
 
 
-evalStateT : StateT s a -> s -> IO a
+evalStateT : StateT s a -> s -> Task Never a
 evalStateT (StateT f) =
     f >> IO.fmap Tuple.first
 
 
-liftIO : IO a -> StateT s a
+liftIO : Task Never a -> StateT s a
 liftIO io =
     StateT (\s -> IO.fmap (\a -> ( a, s )) io)
 
@@ -81,7 +82,7 @@ get =
         )
 
 
-put : IO.ReplState -> IO ()
+put : IO.ReplState -> Task Never ()
 put (IO.ReplState imports types decls) =
     Impure.task "putStateT"
         []

--- a/src/Control/Monad/State/Strict.elm
+++ b/src/Control/Monad/State/Strict.elm
@@ -15,6 +15,7 @@ import Json.Encode as Encode
 import System.IO as IO
 import Task exposing (Task)
 import Utils.Impure as Impure
+import Utils.Task.Extra as TE
 
 
 {-| newtype StateT s m a
@@ -35,12 +36,12 @@ type StateT s a
 
 evalStateT : StateT s a -> s -> Task Never a
 evalStateT (StateT f) =
-    f >> IO.fmap Tuple.first
+    f >> TE.fmap Tuple.first
 
 
 liftIO : Task Never a -> StateT s a
 liftIO io =
-    StateT (\s -> IO.fmap (\a -> ( a, s )) io)
+    StateT (\s -> TE.fmap (\a -> ( a, s )) io)
 
 
 apply : StateT s a -> StateT s (a -> b) -> StateT s b
@@ -48,10 +49,10 @@ apply (StateT arg) (StateT func) =
     StateT
         (\s ->
             arg s
-                |> IO.bind
+                |> TE.bind
                     (\( a, sa ) ->
                         func sa
-                            |> IO.fmap (\( fb, sb ) -> ( fb a, sb ))
+                            |> TE.fmap (\( fb, sb ) -> ( fb a, sb ))
                     )
         )
 
@@ -63,7 +64,7 @@ fmap func argStateT =
 
 pure : a -> StateT s a
 pure value =
-    StateT (\s -> IO.pure ( value, s ))
+    StateT (\s -> TE.pure ( value, s ))
 
 
 get : StateT s IO.ReplState

--- a/src/Node/Main.elm
+++ b/src/Node/Main.elm
@@ -6,7 +6,7 @@ import Node.Format as Format
 import System.IO as IO
 import Task exposing (Task)
 import Utils.Impure as Impure
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 main : IO.Program
@@ -17,7 +17,7 @@ main =
 app : Task Never ()
 app =
     getArgs
-        |> TE.bind
+        |> Task.bind
             (\args ->
                 case args of
                     FormatArgs path ->

--- a/src/Node/Main.elm
+++ b/src/Node/Main.elm
@@ -6,6 +6,7 @@ import Node.Format as Format
 import System.IO as IO
 import Task exposing (Task)
 import Utils.Impure as Impure
+import Utils.Task.Extra as TE
 
 
 main : IO.Program
@@ -16,7 +17,7 @@ main =
 app : Task Never ()
 app =
     getArgs
-        |> IO.bind
+        |> TE.bind
             (\args ->
                 case args of
                     FormatArgs path ->

--- a/src/Node/Main.elm
+++ b/src/Node/Main.elm
@@ -3,7 +3,8 @@ module Node.Main exposing (main)
 import Json.Decode as Decode
 import Json.Encode as Encode
 import Node.Format as Format
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Utils.Impure as Impure
 
 
@@ -12,7 +13,7 @@ main =
     IO.run app
 
 
-app : IO ()
+app : Task Never ()
 app =
     getArgs
         |> IO.bind
@@ -28,12 +29,12 @@ app =
             )
 
 
-getArgs : IO Args
+getArgs : Task Never Args
 getArgs =
     Impure.task "getArgs" [] Impure.EmptyBody (Impure.DecoderResolver argsDecoder)
 
 
-exitWithResponse : Encode.Value -> IO a
+exitWithResponse : Encode.Value -> Task Never a
 exitWithResponse value =
     Impure.task "exitWithResponse" [] (Impure.JsonBody value) Impure.Crash
 

--- a/src/System/Exit.elm
+++ b/src/System/Exit.elm
@@ -5,7 +5,8 @@ module System.Exit exposing
     , exitWith
     )
 
-import System.IO exposing (IO)
+import System.IO
+import Task exposing (Task)
 import Utils.Impure as Impure
 
 
@@ -14,7 +15,7 @@ type ExitCode
     | ExitFailure Int
 
 
-exitWith : ExitCode -> IO a
+exitWith : ExitCode -> Task Never a
 exitWith exitCode =
     let
         code : Int
@@ -32,11 +33,11 @@ exitWith exitCode =
         Impure.Crash
 
 
-exitFailure : IO a
+exitFailure : Task Never a
 exitFailure =
     exitWith (ExitFailure 1)
 
 
-exitSuccess : IO a
+exitSuccess : Task Never a
 exitSuccess =
     exitWith ExitSuccess

--- a/src/System/Exit.elm
+++ b/src/System/Exit.elm
@@ -5,7 +5,6 @@ module System.Exit exposing
     , exitWith
     )
 
-import System.IO
 import Task exposing (Task)
 import Utils.Impure as Impure
 

--- a/src/System/IO.elm
+++ b/src/System/IO.elm
@@ -11,19 +11,11 @@ module System.IO exposing
     , putStr, putStrLn, getLine
     , ReplState(..), initialReplState
     , writeString
-    --, pure, apply, fmap, bind, mapM
-    --, eio, io, mapError, mio, throw, void
     )
 
 {-| Ref.: <https://hackage.haskell.org/package/base-4.20.0.1/docs/System-IO.html>
 
 @docs Program, Model, Msg, run
-
-
-# Task Extra
-
-@docs pure, apply, fmap, bind, mapM
-@docs eio, io, mapError, mio, throw, void
 
 
 # Files and handles
@@ -131,79 +123,9 @@ writeString path content =
 -- Task extra
 
 
-io : Task Never a -> Task x a
-io work =
-    Task.mapError never work
-
-
-mio : x -> Task Never (Maybe a) -> Task x a
-mio x work =
-    work
-        |> Task.mapError never
-        |> Task.andThen
-            (\m ->
-                case m of
-                    Just a ->
-                        Task.succeed a
-
-                    Nothing ->
-                        Task.fail x
-            )
-
-
-eio : (x -> y) -> Task Never (Result x a) -> Task y a
-eio func work =
-    work
-        |> Task.mapError never
-        |> Task.andThen
-            (\m ->
-                case m of
-                    Ok a ->
-                        Task.succeed a
-
-                    Err err ->
-                        func err |> Task.fail
-            )
-
-
-throw : x -> Task x a
-throw x =
-    Task.fail x
-
-
-mapError : (x -> y) -> Task x a -> Task y a
-mapError func task =
-    Task.mapError func task
-
-
-void : Task x a -> Task x ()
-void =
-    Task.map (always ())
-
-
 pure : a -> Task x a
 pure =
     Task.succeed
-
-
-apply : Task x a -> Task x (a -> b) -> Task x b
-apply ma mf =
-    bind (\f -> bind (pure << f) ma) mf
-
-
-fmap : (a -> b) -> Task x a -> Task x b
-fmap =
-    Task.map
-
-
-bind : (a -> Task x b) -> Task x a -> Task x b
-bind =
-    Task.andThen
-
-
-mapM : (a -> Task x b) -> List a -> Task x (List b)
-mapM f =
-    List.map f >> Task.sequence
 
 
 

--- a/src/System/IO.elm
+++ b/src/System/IO.elm
@@ -1,7 +1,5 @@
 module System.IO exposing
     ( Program, Model, Msg, run
-    , pure, apply, fmap, bind, mapM
-    , eio, io, mapError, mio, throw, void
     , FilePath, Handle(..)
     , stdout, stderr
     , withFile, IOMode(..)
@@ -13,6 +11,8 @@ module System.IO exposing
     , putStr, putStrLn, getLine
     , ReplState(..), initialReplState
     , writeString
+    --, pure, apply, fmap, bind, mapM
+    --, eio, io, mapError, mio, throw, void
     )
 
 {-| Ref.: <https://hackage.haskell.org/package/base-4.20.0.1/docs/System-IO.html>

--- a/src/System/Process.elm
+++ b/src/System/Process.elm
@@ -11,7 +11,8 @@ module System.Process exposing
 import Json.Decode as Decode
 import Json.Encode as Encode
 import System.Exit as Exit
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Utils.Impure as Impure
 
 
@@ -47,7 +48,7 @@ proc cmd args =
     }
 
 
-withCreateProcess : CreateProcess -> (Maybe IO.Handle -> Maybe IO.Handle -> Maybe IO.Handle -> ProcessHandle -> IO Exit.ExitCode) -> IO Exit.ExitCode
+withCreateProcess : CreateProcess -> (Maybe IO.Handle -> Maybe IO.Handle -> Maybe IO.Handle -> ProcessHandle -> Task Never Exit.ExitCode) -> Task Never Exit.ExitCode
 withCreateProcess createProcess f =
     Impure.task "withCreateProcess"
         []
@@ -119,7 +120,7 @@ withCreateProcess createProcess f =
             )
 
 
-waitForProcess : ProcessHandle -> IO Exit.ExitCode
+waitForProcess : ProcessHandle -> Task Never Exit.ExitCode
 waitForProcess (ProcessHandle ph) =
     Impure.task "waitForProcess"
         []

--- a/src/System/Process.elm
+++ b/src/System/Process.elm
@@ -14,6 +14,7 @@ import System.Exit as Exit
 import System.IO as IO
 import Task exposing (Task)
 import Utils.Impure as Impure
+import Utils.Task.Extra as TE
 
 
 type CmdSpec
@@ -114,7 +115,7 @@ withCreateProcess createProcess f =
                 (Decode.field "ph" Decode.int)
             )
         )
-        |> IO.bind
+        |> TE.bind
             (\( stdinHandle, ph ) ->
                 f (Maybe.map IO.Handle stdinHandle) Nothing Nothing (ProcessHandle ph)
             )

--- a/src/System/Process.elm
+++ b/src/System/Process.elm
@@ -14,7 +14,7 @@ import System.Exit as Exit
 import System.IO as IO
 import Task exposing (Task)
 import Utils.Impure as Impure
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 type CmdSpec
@@ -115,7 +115,7 @@ withCreateProcess createProcess f =
                 (Decode.field "ph" Decode.int)
             )
         )
-        |> TE.bind
+        |> Task.bind
             (\( stdinHandle, ph ) ->
                 f (Maybe.map IO.Handle stdinHandle) Nothing Nothing (ProcessHandle ph)
             )

--- a/src/Terminal/Bump.elm
+++ b/src/Terminal/Bump.elm
@@ -31,7 +31,7 @@ import Utils.Task.Extra as Task
 run : () -> () -> Task Never ()
 run () () =
     Reporting.attempt Exit.bumpToReport <|
-        Task.toResult (Task.bind bump getEnv)
+        Task.run (Task.bind bump getEnv)
 
 
 

--- a/src/Terminal/Diff.elm
+++ b/src/Terminal/Diff.elm
@@ -45,7 +45,7 @@ type Args
 run : Args -> () -> Task Never ()
 run args () =
     Reporting.attempt Exit.diffToReport
-        (Task.toResult
+        (Task.run
             (getEnv
                 |> Task.bind (\env -> diff env args)
             )

--- a/src/Terminal/Diff.elm
+++ b/src/Terminal/Diff.elm
@@ -14,7 +14,6 @@ import Builder.Http as Http
 import Builder.Reporting as Reporting
 import Builder.Reporting.Exit as Exit
 import Builder.Reporting.Exit.Help as Help
-import Utils.Task.Extra as TE
 import Builder.Stuff as Stuff
 import Compiler.AST.Utils.Binop as Binop
 import Compiler.Data.Name as Name
@@ -29,6 +28,7 @@ import Compiler.Reporting.Render.Type as Type
 import Compiler.Reporting.Render.Type.Localizer as L
 import Data.Map as Dict
 import Task exposing (Task)
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Terminal/Init.elm
+++ b/src/Terminal/Init.elm
@@ -19,7 +19,8 @@ import Compiler.Elm.Package as Pkg
 import Compiler.Elm.Version as V
 import Compiler.Reporting.Doc as D
 import Data.Map as Dict exposing (Dict)
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Utils.Main as Utils
 
 
@@ -31,7 +32,7 @@ type Flags
     = Flags Bool Bool
 
 
-run : () -> Flags -> IO ()
+run : () -> Flags -> Task Never ()
 run () (Flags package autoYes) =
     Reporting.attempt Exit.initToReport <|
         (Utils.dirDoesFileExist "elm.json"
@@ -42,7 +43,7 @@ run () (Flags package autoYes) =
 
                     else
                         let
-                            askQuestion : IO Bool
+                            askQuestion : Task Never Bool
                             askQuestion =
                                 if autoYes then
                                     Help.toStdout (information [ D.fromChars "" ])
@@ -105,7 +106,7 @@ information question =
 -- INIT
 
 
-init : Bool -> IO (Result Exit.Init ())
+init : Bool -> Task Never (Result Exit.Init ())
 init package =
     Solver.initEnv
         |> IO.bind
@@ -207,7 +208,7 @@ init package =
             )
 
 
-verify : Stuff.PackageCache -> Solver.Connection -> Registry.Registry -> Dict ( String, String ) Pkg.Name Con.Constraint -> (Dict ( String, String ) Pkg.Name Solver.Details -> IO (Result Exit.Init ())) -> IO (Result Exit.Init ())
+verify : Stuff.PackageCache -> Solver.Connection -> Registry.Registry -> Dict ( String, String ) Pkg.Name Con.Constraint -> (Dict ( String, String ) Pkg.Name Solver.Details -> Task Never (Result Exit.Init ())) -> Task Never (Result Exit.Init ())
 verify cache connection registry constraints callback =
     Solver.verify cache connection registry constraints
         |> IO.bind

--- a/src/Terminal/Install.elm
+++ b/src/Terminal/Install.elm
@@ -53,7 +53,7 @@ run args (Flags forTest autoYes) =
                                         |> Task.fmap (\elmHome -> Err (Exit.InstallNoArgs elmHome))
 
                                 Install pkg ->
-                                    Task.toResult
+                                    Task.run
                                         (Task.eio Exit.InstallBadRegistry Solver.initEnv
                                             |> Task.bind
                                                 (\env ->

--- a/src/Terminal/Install.elm
+++ b/src/Terminal/Install.elm
@@ -11,14 +11,15 @@ import Builder.Elm.Details as Details
 import Builder.Elm.Outline as Outline
 import Builder.Reporting as Reporting
 import Builder.Reporting.Exit as Exit
-import Builder.Reporting.Task as Task
+import Builder.Reporting.Task as WasRepTask
 import Builder.Stuff as Stuff
 import Compiler.Elm.Constraint as C
 import Compiler.Elm.Package as Pkg
 import Compiler.Elm.Version as V
 import Compiler.Reporting.Doc as D
 import Data.Map as Dict exposing (Dict)
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Utils.Main as Utils exposing (FilePath)
 
 
@@ -35,7 +36,7 @@ type Flags
     = Flags Bool Bool
 
 
-run : Args -> Flags -> IO ()
+run : Args -> Flags -> Task Never ()
 run args (Flags forTest autoYes) =
     Reporting.attempt Exit.installToReport
         (Stuff.findRoot
@@ -52,21 +53,21 @@ run args (Flags forTest autoYes) =
                                         |> IO.fmap (\elmHome -> Err (Exit.InstallNoArgs elmHome))
 
                                 Install pkg ->
-                                    Task.run
-                                        (Task.eio Exit.InstallBadRegistry Solver.initEnv
-                                            |> Task.bind
+                                    WasRepTask.run
+                                        (WasRepTask.eio Exit.InstallBadRegistry Solver.initEnv
+                                            |> WasRepTask.bind
                                                 (\env ->
-                                                    Task.eio Exit.InstallBadOutline (Outline.read root)
-                                                        |> Task.bind
+                                                    WasRepTask.eio Exit.InstallBadOutline (Outline.read root)
+                                                        |> WasRepTask.bind
                                                             (\oldOutline ->
                                                                 case oldOutline of
                                                                     Outline.App outline ->
                                                                         makeAppPlan env pkg outline forTest
-                                                                            |> Task.bind (\changes -> attemptChanges root env oldOutline V.toChars changes autoYes)
+                                                                            |> WasRepTask.bind (\changes -> attemptChanges root env oldOutline V.toChars changes autoYes)
 
                                                                     Outline.Pkg outline ->
                                                                         makePkgPlan env pkg outline forTest
-                                                                            |> Task.bind (\changes -> attemptChanges root env oldOutline C.toChars changes autoYes)
+                                                                            |> WasRepTask.bind (\changes -> attemptChanges root env oldOutline C.toChars changes autoYes)
                                                             )
                                                 )
                                         )
@@ -85,15 +86,11 @@ type Changes vsn
     | Changes (Dict ( String, String ) Pkg.Name (Change vsn)) Outline.Outline
 
 
-type alias Task a =
-    Task.Task Exit.Install a
-
-
-attemptChanges : String -> Solver.Env -> Outline.Outline -> (a -> String) -> Changes a -> Bool -> Task ()
+attemptChanges : String -> Solver.Env -> Outline.Outline -> (a -> String) -> Changes a -> Bool -> Task Exit.Install ()
 attemptChanges root env oldOutline toChars changes autoYes =
     case changes of
         AlreadyInstalled ->
-            Task.io (IO.putStrLn "It is already installed!")
+            WasRepTask.io (IO.putStrLn "It is already installed!")
 
         PromoteIndirect newOutline ->
             attemptChangesHelp root env oldOutline newOutline autoYes <|
@@ -179,13 +176,13 @@ attemptChanges root env oldOutline toChars changes autoYes =
                     ]
 
 
-attemptChangesHelp : FilePath -> Solver.Env -> Outline.Outline -> Outline.Outline -> Bool -> D.Doc -> Task ()
+attemptChangesHelp : FilePath -> Solver.Env -> Outline.Outline -> Outline.Outline -> Bool -> D.Doc -> Task Exit.Install ()
 attemptChangesHelp root env oldOutline newOutline autoYes question =
-    Task.eio Exit.InstallBadDetails <|
+    WasRepTask.eio Exit.InstallBadDetails <|
         BW.withScope
             (\scope ->
                 let
-                    askQuestion : IO Bool
+                    askQuestion : Task Never Bool
                     askQuestion =
                         if autoYes then
                             IO.pure True
@@ -222,17 +219,17 @@ attemptChangesHelp root env oldOutline newOutline autoYes question =
 -- MAKE APP PLAN
 
 
-makeAppPlan : Solver.Env -> Pkg.Name -> Outline.AppOutline -> Bool -> Task (Changes V.Version)
+makeAppPlan : Solver.Env -> Pkg.Name -> Outline.AppOutline -> Bool -> Task Exit.Install (Changes V.Version)
 makeAppPlan (Solver.Env cache _ connection registry) pkg ((Outline.AppOutline elmVersion sourceDirs direct indirect testDirect testIndirect) as outline) forTest =
     if forTest then
         if Dict.member identity pkg testDirect then
-            Task.pure AlreadyInstalled
+            WasRepTask.pure AlreadyInstalled
 
         else
             (-- is it already an indirect test dependency?
              case Dict.get identity pkg testIndirect of
                 Just vsn ->
-                    Task.pure <|
+                    WasRepTask.pure <|
                         PromoteTest <|
                             Outline.App <|
                                 Outline.AppOutline elmVersion
@@ -248,38 +245,38 @@ makeAppPlan (Solver.Env cache _ connection registry) pkg ((Outline.AppOutline el
                         Err suggestions ->
                             case connection of
                                 Solver.Online _ ->
-                                    Task.throw (Exit.InstallUnknownPackageOnline pkg suggestions)
+                                    WasRepTask.throw (Exit.InstallUnknownPackageOnline pkg suggestions)
 
                                 Solver.Offline ->
-                                    Task.throw (Exit.InstallUnknownPackageOffline pkg suggestions)
+                                    WasRepTask.throw (Exit.InstallUnknownPackageOffline pkg suggestions)
 
                         Ok _ ->
-                            Task.io (Solver.addToApp cache connection registry pkg outline forTest)
-                                |> Task.bind
+                            WasRepTask.io (Solver.addToApp cache connection registry pkg outline forTest)
+                                |> WasRepTask.bind
                                     (\result ->
                                         case result of
                                             Solver.SolverOk (Solver.AppSolution old new app) ->
-                                                Task.pure (Changes (detectChanges old new) (Outline.App app))
+                                                WasRepTask.pure (Changes (detectChanges old new) (Outline.App app))
 
                                             Solver.NoSolution ->
-                                                Task.throw (Exit.InstallNoOnlineAppSolution pkg)
+                                                WasRepTask.throw (Exit.InstallNoOnlineAppSolution pkg)
 
                                             Solver.NoOfflineSolution ->
-                                                Task.throw (Exit.InstallNoOfflineAppSolution pkg)
+                                                WasRepTask.throw (Exit.InstallNoOfflineAppSolution pkg)
 
                                             Solver.SolverErr exit ->
-                                                Task.throw (Exit.InstallHadSolverTrouble exit)
+                                                WasRepTask.throw (Exit.InstallHadSolverTrouble exit)
                                     )
             )
 
     else if Dict.member identity pkg direct then
-        Task.pure AlreadyInstalled
+        WasRepTask.pure AlreadyInstalled
 
     else
         -- is it already indirect?
         case Dict.get identity pkg indirect of
             Just vsn ->
-                Task.pure <|
+                WasRepTask.pure <|
                     PromoteIndirect <|
                         Outline.App <|
                             Outline.AppOutline elmVersion
@@ -293,7 +290,7 @@ makeAppPlan (Solver.Env cache _ connection registry) pkg ((Outline.AppOutline el
                 -- is it already a test dependency?
                 case Dict.get identity pkg testDirect of
                     Just vsn ->
-                        Task.pure <|
+                        WasRepTask.pure <|
                             PromoteTest <|
                                 Outline.App <|
                                     Outline.AppOutline elmVersion
@@ -307,7 +304,7 @@ makeAppPlan (Solver.Env cache _ connection registry) pkg ((Outline.AppOutline el
                         -- is it already an indirect test dependency?
                         case Dict.get identity pkg testIndirect of
                             Just vsn ->
-                                Task.pure <|
+                                WasRepTask.pure <|
                                     PromoteTest <|
                                         Outline.App <|
                                             Outline.AppOutline elmVersion
@@ -323,27 +320,27 @@ makeAppPlan (Solver.Env cache _ connection registry) pkg ((Outline.AppOutline el
                                     Err suggestions ->
                                         case connection of
                                             Solver.Online _ ->
-                                                Task.throw (Exit.InstallUnknownPackageOnline pkg suggestions)
+                                                WasRepTask.throw (Exit.InstallUnknownPackageOnline pkg suggestions)
 
                                             Solver.Offline ->
-                                                Task.throw (Exit.InstallUnknownPackageOffline pkg suggestions)
+                                                WasRepTask.throw (Exit.InstallUnknownPackageOffline pkg suggestions)
 
                                     Ok _ ->
-                                        Task.io (Solver.addToApp cache connection registry pkg outline forTest)
-                                            |> Task.bind
+                                        WasRepTask.io (Solver.addToApp cache connection registry pkg outline forTest)
+                                            |> WasRepTask.bind
                                                 (\result ->
                                                     case result of
                                                         Solver.SolverOk (Solver.AppSolution old new app) ->
-                                                            Task.pure (Changes (detectChanges old new) (Outline.App app))
+                                                            WasRepTask.pure (Changes (detectChanges old new) (Outline.App app))
 
                                                         Solver.NoSolution ->
-                                                            Task.throw (Exit.InstallNoOnlineAppSolution pkg)
+                                                            WasRepTask.throw (Exit.InstallNoOnlineAppSolution pkg)
 
                                                         Solver.NoOfflineSolution ->
-                                                            Task.throw (Exit.InstallNoOfflineAppSolution pkg)
+                                                            WasRepTask.throw (Exit.InstallNoOfflineAppSolution pkg)
 
                                                         Solver.SolverErr exit ->
-                                                            Task.throw (Exit.InstallHadSolverTrouble exit)
+                                                            WasRepTask.throw (Exit.InstallHadSolverTrouble exit)
                                                 )
 
 
@@ -351,11 +348,11 @@ makeAppPlan (Solver.Env cache _ connection registry) pkg ((Outline.AppOutline el
 -- MAKE PACKAGE PLAN
 
 
-makePkgPlan : Solver.Env -> Pkg.Name -> Outline.PkgOutline -> Bool -> Task (Changes C.Constraint)
+makePkgPlan : Solver.Env -> Pkg.Name -> Outline.PkgOutline -> Bool -> Task Exit.Install (Changes C.Constraint)
 makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline name summary license version exposed deps test elmVersion) forTest =
     if forTest then
         if Dict.member identity pkg test then
-            Task.pure AlreadyInstalled
+            WasRepTask.pure AlreadyInstalled
 
         else
             -- try to add a new dependency
@@ -363,10 +360,10 @@ makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline nam
                 Err suggestions ->
                     case connection of
                         Solver.Online _ ->
-                            Task.throw (Exit.InstallUnknownPackageOnline pkg suggestions)
+                            WasRepTask.throw (Exit.InstallUnknownPackageOnline pkg suggestions)
 
                         Solver.Offline ->
-                            Task.throw (Exit.InstallUnknownPackageOffline pkg suggestions)
+                            WasRepTask.throw (Exit.InstallUnknownPackageOffline pkg suggestions)
 
                 Ok (Registry.KnownVersions _ _) ->
                     let
@@ -374,8 +371,8 @@ makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline nam
                         cons =
                             Dict.insert identity pkg C.anything test
                     in
-                    Task.io (Solver.verify cache connection registry cons)
-                        |> Task.bind
+                    WasRepTask.io (Solver.verify cache connection registry cons)
+                        |> WasRepTask.bind
                             (\result ->
                                 case result of
                                     Solver.SolverOk solution ->
@@ -399,7 +396,7 @@ makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline nam
                                             news =
                                                 Utils.mapMapMaybe identity Pkg.compareName keepNew changes
                                         in
-                                        Task.pure <|
+                                        WasRepTask.pure <|
                                             Changes changes <|
                                                 Outline.Pkg <|
                                                     Outline.PkgOutline name
@@ -412,23 +409,23 @@ makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline nam
                                                         elmVersion
 
                                     Solver.NoSolution ->
-                                        Task.throw (Exit.InstallNoOnlinePkgSolution pkg)
+                                        WasRepTask.throw (Exit.InstallNoOnlinePkgSolution pkg)
 
                                     Solver.NoOfflineSolution ->
-                                        Task.throw (Exit.InstallNoOfflinePkgSolution pkg)
+                                        WasRepTask.throw (Exit.InstallNoOfflinePkgSolution pkg)
 
                                     Solver.SolverErr exit ->
-                                        Task.throw (Exit.InstallHadSolverTrouble exit)
+                                        WasRepTask.throw (Exit.InstallHadSolverTrouble exit)
                             )
 
     else if Dict.member identity pkg deps then
-        Task.pure AlreadyInstalled
+        WasRepTask.pure AlreadyInstalled
 
     else
         -- is already in test dependencies?
         case Dict.get identity pkg test of
             Just con ->
-                Task.pure <|
+                WasRepTask.pure <|
                     PromoteTest <|
                         Outline.Pkg <|
                             Outline.PkgOutline name
@@ -446,10 +443,10 @@ makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline nam
                     Err suggestions ->
                         case connection of
                             Solver.Online _ ->
-                                Task.throw (Exit.InstallUnknownPackageOnline pkg suggestions)
+                                WasRepTask.throw (Exit.InstallUnknownPackageOnline pkg suggestions)
 
                             Solver.Offline ->
-                                Task.throw (Exit.InstallUnknownPackageOffline pkg suggestions)
+                                WasRepTask.throw (Exit.InstallUnknownPackageOffline pkg suggestions)
 
                     Ok (Registry.KnownVersions _ _) ->
                         let
@@ -461,8 +458,8 @@ makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline nam
                             cons =
                                 Dict.insert identity pkg C.anything old
                         in
-                        Task.io (Solver.verify cache connection registry cons)
-                            |> Task.bind
+                        WasRepTask.io (Solver.verify cache connection registry cons)
+                            |> WasRepTask.bind
                                 (\result ->
                                     case result of
                                         Solver.SolverOk solution ->
@@ -486,7 +483,7 @@ makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline nam
                                                 news =
                                                     Utils.mapMapMaybe identity Pkg.compareName keepNew changes
                                             in
-                                            Task.pure <|
+                                            WasRepTask.pure <|
                                                 Changes changes <|
                                                     Outline.Pkg <|
                                                         Outline.PkgOutline name
@@ -499,13 +496,13 @@ makePkgPlan (Solver.Env cache _ connection registry) pkg (Outline.PkgOutline nam
                                                             elmVersion
 
                                         Solver.NoSolution ->
-                                            Task.throw (Exit.InstallNoOnlinePkgSolution pkg)
+                                            WasRepTask.throw (Exit.InstallNoOnlinePkgSolution pkg)
 
                                         Solver.NoOfflineSolution ->
-                                            Task.throw (Exit.InstallNoOfflinePkgSolution pkg)
+                                            WasRepTask.throw (Exit.InstallNoOfflinePkgSolution pkg)
 
                                         Solver.SolverErr exit ->
-                                            Task.throw (Exit.InstallHadSolverTrouble exit)
+                                            WasRepTask.throw (Exit.InstallHadSolverTrouble exit)
                                 )
 
 

--- a/src/Terminal/Main.elm
+++ b/src/Terminal/Main.elm
@@ -19,13 +19,14 @@ import Terminal.Terminal.Internal as Terminal
 import Terminal.Test as Test
 import Terminal.Uninstall as Uninstall
 import Utils.Impure as Impure
+import Utils.Task.Extra as TE
 
 
 main : IO.Program
 main =
     IO.run
         (app
-            |> IO.bind
+            |> TE.bind
                 (\() ->
                     Impure.task "exitWith"
                         []
@@ -179,8 +180,8 @@ interpreter =
     Terminal.Parser
         { singular = "interpreter"
         , plural = "interpreters"
-        , suggest = \_ -> IO.pure []
-        , examples = \_ -> IO.pure [ "node", "nodejs" ]
+        , suggest = \_ -> TE.pure []
+        , examples = \_ -> TE.pure [ "node", "nodejs" ]
         }
 
 
@@ -583,8 +584,8 @@ output =
     Terminal.Parser
         { singular = "output"
         , plural = "outputs"
-        , suggest = \_ -> IO.pure []
-        , examples = \_ -> IO.pure []
+        , suggest = \_ -> TE.pure []
+        , examples = \_ -> TE.pure []
         }
 
 
@@ -645,8 +646,8 @@ int =
     Terminal.Parser
         { singular = "int"
         , plural = "ints"
-        , suggest = \_ -> IO.pure []
-        , examples = \_ -> IO.pure []
+        , suggest = \_ -> TE.pure []
+        , examples = \_ -> TE.pure []
         }
 
 

--- a/src/Terminal/Main.elm
+++ b/src/Terminal/Main.elm
@@ -2,7 +2,8 @@ module Terminal.Main exposing (main)
 
 import Compiler.Elm.Version as V
 import Compiler.Reporting.Doc as D
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Terminal.Bump as Bump
 import Terminal.Diff as Diff
 import Terminal.Format as Format
@@ -34,7 +35,7 @@ main =
         )
 
 
-app : IO ()
+app : Task Never ()
 app =
     Terminal.app intro
         outro

--- a/src/Terminal/Main.elm
+++ b/src/Terminal/Main.elm
@@ -19,14 +19,14 @@ import Terminal.Terminal.Internal as Terminal
 import Terminal.Test as Test
 import Terminal.Uninstall as Uninstall
 import Utils.Impure as Impure
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 main : IO.Program
 main =
     IO.run
         (app
-            |> TE.bind
+            |> Task.bind
                 (\() ->
                     Impure.task "exitWith"
                         []
@@ -180,8 +180,8 @@ interpreter =
     Terminal.Parser
         { singular = "interpreter"
         , plural = "interpreters"
-        , suggest = \_ -> TE.pure []
-        , examples = \_ -> TE.pure [ "node", "nodejs" ]
+        , suggest = \_ -> Task.pure []
+        , examples = \_ -> Task.pure [ "node", "nodejs" ]
         }
 
 
@@ -584,8 +584,8 @@ output =
     Terminal.Parser
         { singular = "output"
         , plural = "outputs"
-        , suggest = \_ -> TE.pure []
-        , examples = \_ -> TE.pure []
+        , suggest = \_ -> Task.pure []
+        , examples = \_ -> Task.pure []
         }
 
 
@@ -646,8 +646,8 @@ int =
     Terminal.Parser
         { singular = "int"
         , plural = "ints"
-        , suggest = \_ -> TE.pure []
-        , examples = \_ -> TE.pure []
+        , suggest = \_ -> Task.pure []
+        , examples = \_ -> Task.pure []
         }
 
 

--- a/src/Terminal/Make.elm
+++ b/src/Terminal/Make.elm
@@ -78,7 +78,7 @@ runHelp root paths style (Flags debug optimize withSourceMaps maybeOutput _ mayb
     BW.withScope
         (\scope ->
             Stuff.withRootLock root <|
-                Task.toResult <|
+                Task.run <|
                     (getMode debug optimize
                         |> Task.bind
                             (\desiredMode ->

--- a/src/Terminal/Make.elm
+++ b/src/Terminal/Make.elm
@@ -18,19 +18,18 @@ import Builder.File as File
 import Builder.Generate as Generate
 import Builder.Reporting as Reporting
 import Builder.Reporting.Exit as Exit
-import Utils.Task.Extra as TE
 import Builder.Stuff as Stuff
 import Compiler.AST.Optimized as Opt
 import Compiler.Data.NonEmptyList as NE
 import Compiler.Elm.ModuleName as ModuleName
 import Compiler.Generate.Html as Html
 import Maybe.Extra as Maybe
-import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Terminal.Terminal.Internal exposing (Parser(..))
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE
 import Utils.Main as Utils exposing (FilePath)
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Terminal/Publish.elm
+++ b/src/Terminal/Publish.elm
@@ -41,7 +41,7 @@ optimization to skip builds in Elm.Details always valid
 run : () -> () -> Task Never ()
 run () () =
     Reporting.attempt Exit.publishToReport <|
-        Task.toResult (Task.bind publish getEnv)
+        Task.run (Task.bind publish getEnv)
 
 
 
@@ -222,7 +222,7 @@ verifyBuild root =
     reportBuildCheck <|
         BW.withScope <|
             \scope ->
-                Task.toResult
+                Task.run
                     (Task.eio Exit.PublishBadDetails
                         (Details.load Reporting.silent scope root)
                         |> Task.bind
@@ -400,14 +400,14 @@ withPrepublishDir root callback =
         Utils.bracket_
             (Utils.dirCreateDirectoryIfMissing True dir)
             (Utils.dirRemoveDirectoryRecursive dir)
-            (Task.toResult (callback dir))
+            (Task.run (callback dir))
 
 
 verifyZipBuild : FilePath -> Task Never (Result Exit.Publish ())
 verifyZipBuild root =
     BW.withScope
         (\scope ->
-            Task.toResult
+            Task.run
                 (Task.eio Exit.PublishZipBadDetails
                     (Details.load Reporting.silent scope root)
                     |> Task.bind

--- a/src/Terminal/Repl.elm
+++ b/src/Terminal/Repl.elm
@@ -590,7 +590,7 @@ attemptEval (Env root interpreter ansi) oldState newState output =
     BW.withScope
         (\scope ->
             Stuff.withRootLock root
-                (Task.toResult
+                (Task.run
                     (Task.eio Exit.ReplBadDetails
                         (Details.load Reporting.silent scope root)
                         |> Task.bind

--- a/src/Terminal/Terminal.elm
+++ b/src/Terminal/Terminal.elm
@@ -23,6 +23,7 @@ import Task exposing (Task)
 import Terminal.Terminal.Error as Error
 import Terminal.Terminal.Internal exposing (Args(..), Command(..), CompleteArgs(..), Flag(..), Flags(..), Parser, RequiredArgs(..), toName)
 import Utils.Main as Utils
+import Utils.Task.Extra as TE
 
 
 
@@ -32,7 +33,7 @@ import Utils.Main as Utils
 app : D.Doc -> D.Doc -> List Command -> Task Never ()
 app intro outro commands =
     Utils.envGetArgs
-        |> IO.bind
+        |> TE.bind
             (\argStrings ->
                 case argStrings of
                     [] ->
@@ -43,7 +44,7 @@ app intro outro commands =
 
                     [ "--version" ] ->
                         IO.hPutStrLn IO.stdout (V.toChars V.compiler)
-                            |> IO.bind (\_ -> Exit.exitSuccess)
+                            |> TE.bind (\_ -> Exit.exitSuccess)
 
                     command :: chunks ->
                         case List.find (\cmd -> toName cmd == command) commands of

--- a/src/Terminal/Terminal.elm
+++ b/src/Terminal/Terminal.elm
@@ -18,7 +18,8 @@ import Compiler.Elm.Version as V
 import Compiler.Reporting.Doc as D
 import List.Extra as List
 import System.Exit as Exit
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Terminal.Terminal.Error as Error
 import Terminal.Terminal.Internal exposing (Args(..), Command(..), CompleteArgs(..), Flag(..), Flags(..), Parser, RequiredArgs(..), toName)
 import Utils.Main as Utils
@@ -28,7 +29,7 @@ import Utils.Main as Utils
 -- APP
 
 
-app : D.Doc -> D.Doc -> List Command -> IO ()
+app : D.Doc -> D.Doc -> List Command -> Task Never ()
 app intro outro commands =
     Utils.envGetArgs
         |> IO.bind

--- a/src/Terminal/Terminal.elm
+++ b/src/Terminal/Terminal.elm
@@ -23,7 +23,7 @@ import Task exposing (Task)
 import Terminal.Terminal.Error as Error
 import Terminal.Terminal.Internal exposing (Args(..), Command(..), CompleteArgs(..), Flag(..), Flags(..), Parser, RequiredArgs(..), toName)
 import Utils.Main as Utils
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 
@@ -33,7 +33,7 @@ import Utils.Task.Extra as TE
 app : D.Doc -> D.Doc -> List Command -> Task Never ()
 app intro outro commands =
     Utils.envGetArgs
-        |> TE.bind
+        |> Task.bind
             (\argStrings ->
                 case argStrings of
                     [] ->
@@ -44,7 +44,7 @@ app intro outro commands =
 
                     [ "--version" ] ->
                         IO.hPutStrLn IO.stdout (V.toChars V.compiler)
-                            |> TE.bind (\_ -> Exit.exitSuccess)
+                            |> Task.bind (\_ -> Exit.exitSuccess)
 
                     command :: chunks ->
                         case List.find (\cmd -> toName cmd == command) commands of

--- a/src/Terminal/Terminal/Chomp.elm
+++ b/src/Terminal/Terminal/Chomp.elm
@@ -19,7 +19,7 @@ import Basics.Extra exposing (flip)
 import Maybe.Extra as Maybe
 import Task exposing (Task)
 import Terminal.Terminal.Internal exposing (ArgError(..), Error(..), Expectation(..), Flag(..), FlagError(..), Flags(..), Parser(..))
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 
@@ -38,7 +38,7 @@ chomp maybeIndex strings args (Chomper flagChomper) =
             Tuple.mapSecond (Result.map (\a -> ( a, flagValue ))) (chompArgs suggest chunks args)
 
         ChomperErr suggest flagError ->
-            ( addSuggest (TE.pure []) suggest, Err (BadFlag flagError) )
+            ( addSuggest (Task.pure []) suggest, Err (BadFlag flagError) )
 
 
 toChunks : List String -> List Chunk
@@ -115,7 +115,7 @@ chompArgsHelp :
 chompArgsHelp suggest chunks completeArgsList revSuggest revArgErrors =
     case completeArgsList of
         [] ->
-            ( List.foldl (flip addSuggest) (TE.pure []) revSuggest
+            ( List.foldl (flip addSuggest) (Task.pure []) revSuggest
             , Err (BadArgs (List.reverse revArgErrors))
             )
 
@@ -125,7 +125,7 @@ chompArgsHelp suggest chunks completeArgsList revSuggest revArgErrors =
                     chompArgsHelp suggest chunks others (s1 :: revSuggest) (argError :: revArgErrors)
 
                 ( s1, Ok value ) ->
-                    ( addSuggest (TE.pure []) s1
+                    ( addSuggest (Task.pure []) s1
                     , Ok value
                     )
 
@@ -140,9 +140,9 @@ addSuggest everything suggest =
             everything
 
         Suggestions newStuff ->
-            TE.pure (++)
-                |> TE.apply newStuff
-                |> TE.apply everything
+            Task.pure (++)
+                |> Task.apply newStuff
+                |> Task.apply everything
 
 
 
@@ -391,7 +391,7 @@ suggestFlag unknownFlags flags targetIndex =
 
         (Chunk index string) :: otherUnknownFlags ->
             if index == targetIndex then
-                Just (TE.pure (List.filter (String.startsWith string) (getFlagNames flags [])))
+                Just (Task.pure (List.filter (String.startsWith string) (getFlagNames flags [])))
 
             else
                 suggestFlag otherUnknownFlags flags targetIndex

--- a/src/Terminal/Terminal/Chomp.elm
+++ b/src/Terminal/Terminal/Chomp.elm
@@ -17,7 +17,7 @@ module Terminal.Terminal.Chomp exposing
 
 import Basics.Extra exposing (flip)
 import Maybe.Extra as Maybe
-import System.IO as IO
+import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Terminal.Terminal.Internal exposing (ArgError(..), Error(..), Expectation(..), Flag(..), FlagError(..), Flags(..), Parser(..))
 
@@ -38,7 +38,7 @@ chomp maybeIndex strings args (Chomper flagChomper) =
             Tuple.mapSecond (Result.map (\a -> ( a, flagValue ))) (chompArgs suggest chunks args)
 
         ChomperErr suggest flagError ->
-            ( addSuggest (IO.pure []) suggest, Err (BadFlag flagError) )
+            ( addSuggest (TE.pure []) suggest, Err (BadFlag flagError) )
 
 
 toChunks : List String -> List Chunk
@@ -115,7 +115,7 @@ chompArgsHelp :
 chompArgsHelp suggest chunks completeArgsList revSuggest revArgErrors =
     case completeArgsList of
         [] ->
-            ( List.foldl (flip addSuggest) (IO.pure []) revSuggest
+            ( List.foldl (flip addSuggest) (TE.pure []) revSuggest
             , Err (BadArgs (List.reverse revArgErrors))
             )
 
@@ -125,7 +125,7 @@ chompArgsHelp suggest chunks completeArgsList revSuggest revArgErrors =
                     chompArgsHelp suggest chunks others (s1 :: revSuggest) (argError :: revArgErrors)
 
                 ( s1, Ok value ) ->
-                    ( addSuggest (IO.pure []) s1
+                    ( addSuggest (TE.pure []) s1
                     , Ok value
                     )
 
@@ -140,9 +140,9 @@ addSuggest everything suggest =
             everything
 
         Suggestions newStuff ->
-            IO.pure (++)
-                |> IO.apply newStuff
-                |> IO.apply everything
+            TE.pure (++)
+                |> TE.apply newStuff
+                |> TE.apply everything
 
 
 
@@ -391,7 +391,7 @@ suggestFlag unknownFlags flags targetIndex =
 
         (Chunk index string) :: otherUnknownFlags ->
             if index == targetIndex then
-                Just (IO.pure (List.filter (String.startsWith string) (getFlagNames flags [])))
+                Just (TE.pure (List.filter (String.startsWith string) (getFlagNames flags [])))
 
             else
                 suggestFlag otherUnknownFlags flags targetIndex

--- a/src/Terminal/Terminal/Chomp.elm
+++ b/src/Terminal/Terminal/Chomp.elm
@@ -17,9 +17,9 @@ module Terminal.Terminal.Chomp exposing
 
 import Basics.Extra exposing (flip)
 import Maybe.Extra as Maybe
-import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Terminal.Terminal.Internal exposing (ArgError(..), Error(..), Expectation(..), Flag(..), FlagError(..), Flags(..), Parser(..))
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Terminal/Terminal/Error.elm
+++ b/src/Terminal/Terminal/Error.elm
@@ -9,7 +9,8 @@ import Compiler.Reporting.Suggest as Suggest
 import List.Extra as List
 import Prelude
 import System.Exit as Exit
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Terminal.Terminal.Internal
     exposing
         ( ArgError(..)
@@ -34,17 +35,17 @@ import Utils.Main as Utils
 -- EXIT
 
 
-exitSuccess : List P.Doc -> IO a
+exitSuccess : List P.Doc -> Task Never a
 exitSuccess =
     exitWith Exit.ExitSuccess
 
 
-exitFailure : List P.Doc -> IO a
+exitFailure : List P.Doc -> Task Never a
 exitFailure =
     exitWith (Exit.ExitFailure 1)
 
 
-exitWith : Exit.ExitCode -> List P.Doc -> IO a
+exitWith : Exit.ExitCode -> List P.Doc -> Task Never a
 exitWith code docs =
     IO.hIsTerminalDevice IO.stderr
         |> IO.bind
@@ -68,7 +69,7 @@ exitWith code docs =
             )
 
 
-getExeName : IO String
+getExeName : Task Never String
 getExeName =
     IO.fmap Utils.fpTakeFileName Utils.envGetProgName
 
@@ -87,7 +88,7 @@ reflow string =
 -- HELP
 
 
-exitWithHelp : Maybe String -> String -> P.Doc -> Args -> Flags -> IO a
+exitWithHelp : Maybe String -> String -> P.Doc -> Args -> Flags -> Task Never a
 exitWithHelp maybeCommand details example (Args args) flags =
     toCommand maybeCommand
         |> IO.bind
@@ -109,7 +110,7 @@ exitWithHelp maybeCommand details example (Args args) flags =
             )
 
 
-toCommand : Maybe String -> IO String
+toCommand : Maybe String -> Task Never String
 toCommand maybeCommand =
     getExeName
         |> IO.fmap
@@ -190,7 +191,7 @@ flagsToDocs flags docs =
 -- OVERVIEW
 
 
-exitWithOverview : P.Doc -> P.Doc -> List Command -> IO a
+exitWithOverview : P.Doc -> P.Doc -> List Command -> Task Never a
 exitWithOverview intro outro commands =
     getExeName
         |> IO.bind
@@ -249,7 +250,7 @@ toCommandList exeName commands =
 -- UNKNOWN
 
 
-exitWithUnknown : String -> List String -> IO a
+exitWithUnknown : String -> List String -> Task Never a
 exitWithUnknown unknown knowns =
     let
         nearbyKnowns : List ( Int, String )
@@ -294,7 +295,7 @@ exitWithUnknown unknown knowns =
 -- ERROR TO DOC
 
 
-exitWithError : Error -> IO a
+exitWithError : Error -> Task Never a
 exitWithError err =
     IO.bind exitFailure
         (case err of
@@ -351,7 +352,7 @@ toRed str =
 -- ARG ERROR TO DOC
 
 
-argErrorToDocs : ArgError -> IO (List P.Doc)
+argErrorToDocs : ArgError -> Task Never (List P.Doc)
 argErrorToDocs argError =
     case argError of
         ArgMissing (Expectation tipe makeExamples) ->
@@ -432,7 +433,7 @@ argErrorToDocs argError =
 -- FLAG ERROR TO DOC
 
 
-flagErrorHelp : String -> String -> List P.Doc -> IO (List P.Doc)
+flagErrorHelp : String -> String -> List P.Doc -> Task Never (List P.Doc)
 flagErrorHelp summary original explanation =
     IO.pure <|
         [ reflow summary
@@ -441,7 +442,7 @@ flagErrorHelp summary original explanation =
             ++ explanation
 
 
-flagErrorToDocs : FlagError -> IO (List P.Doc)
+flagErrorToDocs : FlagError -> Task Never (List P.Doc)
 flagErrorToDocs flagError =
     case flagError of
         FlagWithValue flagName value ->

--- a/src/Terminal/Terminal/Helpers.elm
+++ b/src/Terminal/Terminal/Helpers.elm
@@ -16,7 +16,8 @@ import Compiler.Elm.Version as V
 import Compiler.Parse.Primitives as P
 import Compiler.Reporting.Suggest as Suggest
 import Data.Map as Dict
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 import Terminal.Terminal.Internal exposing (Parser(..))
 import Utils.Main as Utils exposing (FilePath)
 
@@ -45,7 +46,7 @@ parseVersion chars =
             Nothing
 
 
-suggestVersion : String -> IO (List String)
+suggestVersion : String -> Task Never (List String)
 suggestVersion _ =
     IO.pure []
 
@@ -106,7 +107,7 @@ parseGuidaOrElmFile chars =
             Nothing
 
 
-exampleGuidaOrElmFiles : String -> IO (List String)
+exampleGuidaOrElmFiles : String -> Task Never (List String)
 exampleGuidaOrElmFiles _ =
     IO.pure [ "Main.guida", "src/Main.guida", "Main.elm" ]
 
@@ -130,7 +131,7 @@ parseFilePath =
     Just
 
 
-exampleFilePaths : String -> IO (List String)
+exampleFilePaths : String -> Task Never (List String)
 exampleFilePaths _ =
     IO.pure [ "Main.elm", "src" ]
 
@@ -159,7 +160,7 @@ parsePackage chars =
             Nothing
 
 
-suggestPackages : String -> IO (List String)
+suggestPackages : String -> Task Never (List String)
 suggestPackages given =
     Stuff.getPackageCache
         |> IO.bind
@@ -178,7 +179,7 @@ suggestPackages given =
             )
 
 
-examplePackages : String -> IO (List String)
+examplePackages : String -> Task Never (List String)
 examplePackages given =
     Stuff.getPackageCache
         |> IO.bind

--- a/src/Terminal/Terminal/Helpers.elm
+++ b/src/Terminal/Terminal/Helpers.elm
@@ -19,7 +19,7 @@ import Data.Map as Dict
 import Task exposing (Task)
 import Terminal.Terminal.Internal exposing (Parser(..))
 import Utils.Main as Utils exposing (FilePath)
-import Utils.Task.Extra as TE
+import Utils.Task.Extra as Task
 
 
 
@@ -32,7 +32,7 @@ version =
         { singular = "version"
         , plural = "versions"
         , suggest = suggestVersion
-        , examples = TE.pure << exampleVersions
+        , examples = Task.pure << exampleVersions
         }
 
 
@@ -48,7 +48,7 @@ parseVersion chars =
 
 suggestVersion : String -> Task Never (List String)
 suggestVersion _ =
-    TE.pure []
+    Task.pure []
 
 
 exampleVersions : String -> List String
@@ -89,7 +89,7 @@ guidaOrElmFile =
     Parser
         { singular = "guida or elm file"
         , plural = "guida or elm files"
-        , suggest = \_ -> TE.pure []
+        , suggest = \_ -> Task.pure []
         , examples = exampleGuidaOrElmFiles
         }
 
@@ -109,7 +109,7 @@ parseGuidaOrElmFile chars =
 
 exampleGuidaOrElmFiles : String -> Task Never (List String)
 exampleGuidaOrElmFiles _ =
-    TE.pure [ "Main.guida", "src/Main.guida", "Main.elm" ]
+    Task.pure [ "Main.guida", "src/Main.guida", "Main.elm" ]
 
 
 
@@ -121,7 +121,7 @@ filePath =
     Parser
         { singular = "file path"
         , plural = "file paths"
-        , suggest = \_ -> TE.pure []
+        , suggest = \_ -> Task.pure []
         , examples = exampleFilePaths
         }
 
@@ -133,7 +133,7 @@ parseFilePath =
 
 exampleFilePaths : String -> Task Never (List String)
 exampleFilePaths _ =
-    TE.pure [ "Main.elm", "src" ]
+    Task.pure [ "Main.elm", "src" ]
 
 
 
@@ -163,10 +163,10 @@ parsePackage chars =
 suggestPackages : String -> Task Never (List String)
 suggestPackages given =
     Stuff.getPackageCache
-        |> TE.bind
+        |> Task.bind
             (\cache ->
                 Registry.read cache
-                    |> TE.fmap
+                    |> Task.fmap
                         (\maybeRegistry ->
                             case maybeRegistry of
                                 Nothing ->
@@ -182,10 +182,10 @@ suggestPackages given =
 examplePackages : String -> Task Never (List String)
 examplePackages given =
     Stuff.getPackageCache
-        |> TE.bind
+        |> Task.bind
             (\cache ->
                 Registry.read cache
-                    |> TE.fmap
+                    |> Task.fmap
                         (\maybeRegistry ->
                             case maybeRegistry of
                                 Nothing ->

--- a/src/Terminal/Terminal/Helpers.elm
+++ b/src/Terminal/Terminal/Helpers.elm
@@ -16,10 +16,10 @@ import Compiler.Elm.Version as V
 import Compiler.Parse.Primitives as P
 import Compiler.Reporting.Suggest as Suggest
 import Data.Map as Dict
-import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Terminal.Terminal.Internal exposing (Parser(..))
 import Utils.Main as Utils exposing (FilePath)
+import Utils.Task.Extra as TE
 
 
 

--- a/src/Terminal/Terminal/Helpers.elm
+++ b/src/Terminal/Terminal/Helpers.elm
@@ -16,7 +16,7 @@ import Compiler.Elm.Version as V
 import Compiler.Parse.Primitives as P
 import Compiler.Reporting.Suggest as Suggest
 import Data.Map as Dict
-import System.IO as IO
+import Utils.Task.Extra as TE
 import Task exposing (Task)
 import Terminal.Terminal.Internal exposing (Parser(..))
 import Utils.Main as Utils exposing (FilePath)
@@ -32,7 +32,7 @@ version =
         { singular = "version"
         , plural = "versions"
         , suggest = suggestVersion
-        , examples = IO.pure << exampleVersions
+        , examples = TE.pure << exampleVersions
         }
 
 
@@ -48,7 +48,7 @@ parseVersion chars =
 
 suggestVersion : String -> Task Never (List String)
 suggestVersion _ =
-    IO.pure []
+    TE.pure []
 
 
 exampleVersions : String -> List String
@@ -89,7 +89,7 @@ guidaOrElmFile =
     Parser
         { singular = "guida or elm file"
         , plural = "guida or elm files"
-        , suggest = \_ -> IO.pure []
+        , suggest = \_ -> TE.pure []
         , examples = exampleGuidaOrElmFiles
         }
 
@@ -109,7 +109,7 @@ parseGuidaOrElmFile chars =
 
 exampleGuidaOrElmFiles : String -> Task Never (List String)
 exampleGuidaOrElmFiles _ =
-    IO.pure [ "Main.guida", "src/Main.guida", "Main.elm" ]
+    TE.pure [ "Main.guida", "src/Main.guida", "Main.elm" ]
 
 
 
@@ -121,7 +121,7 @@ filePath =
     Parser
         { singular = "file path"
         , plural = "file paths"
-        , suggest = \_ -> IO.pure []
+        , suggest = \_ -> TE.pure []
         , examples = exampleFilePaths
         }
 
@@ -133,7 +133,7 @@ parseFilePath =
 
 exampleFilePaths : String -> Task Never (List String)
 exampleFilePaths _ =
-    IO.pure [ "Main.elm", "src" ]
+    TE.pure [ "Main.elm", "src" ]
 
 
 
@@ -163,10 +163,10 @@ parsePackage chars =
 suggestPackages : String -> Task Never (List String)
 suggestPackages given =
     Stuff.getPackageCache
-        |> IO.bind
+        |> TE.bind
             (\cache ->
                 Registry.read cache
-                    |> IO.fmap
+                    |> TE.fmap
                         (\maybeRegistry ->
                             case maybeRegistry of
                                 Nothing ->
@@ -182,10 +182,10 @@ suggestPackages given =
 examplePackages : String -> Task Never (List String)
 examplePackages given =
     Stuff.getPackageCache
-        |> IO.bind
+        |> TE.bind
             (\cache ->
                 Registry.read cache
-                    |> IO.fmap
+                    |> TE.fmap
                         (\maybeRegistry ->
                             case maybeRegistry of
                                 Nothing ->

--- a/src/Terminal/Terminal/Internal.elm
+++ b/src/Terminal/Terminal/Internal.elm
@@ -14,7 +14,8 @@ module Terminal.Terminal.Internal exposing
     , toName
     )
 
-import System.IO exposing (IO)
+import System.IO
+import Task exposing (Task)
 import Text.PrettyPrint.ANSI.Leijen exposing (Doc)
 
 
@@ -23,7 +24,7 @@ import Text.PrettyPrint.ANSI.Leijen exposing (Doc)
 
 
 type Command
-    = Command String Summary String Doc Args Flags (List String -> Result Error (IO ()))
+    = Command String Summary String Doc Args Flags (List String -> Result Error (Task Never ()))
 
 
 toName : Command -> String
@@ -65,8 +66,8 @@ type Parser
         , plural : String
 
         -- ,parser : String -> Maybe a
-        , suggest : String -> IO (List String)
-        , examples : String -> IO (List String)
+        , suggest : String -> Task Never (List String)
+        , examples : String -> Task Never (List String)
         }
 
 
@@ -111,4 +112,4 @@ type FlagError
 
 
 type Expectation
-    = Expectation String (IO (List String))
+    = Expectation String (Task Never (List String))

--- a/src/Terminal/Terminal/Internal.elm
+++ b/src/Terminal/Terminal/Internal.elm
@@ -14,7 +14,6 @@ module Terminal.Terminal.Internal exposing
     , toName
     )
 
-import System.IO
 import Task exposing (Task)
 import Text.PrettyPrint.ANSI.Leijen exposing (Doc)
 

--- a/src/Terminal/Test.elm
+++ b/src/Terminal/Test.elm
@@ -66,7 +66,7 @@ run paths flags =
 runHelp : String -> List String -> Flags -> Task Never (Result Exit.Test ())
 runHelp root testFileGlobs flags =
     Stuff.withRootLock root <|
-        Task.toResult <|
+        Task.run <|
             (Utils.dirCreateDirectoryIfMissing True (Stuff.testDir root)
                 |> Task.bind (\_ -> Utils.nodeGetDirname)
                 |> Task.io
@@ -1076,7 +1076,7 @@ runMake : String -> String -> Task Never (Result Exit.Test String)
 runMake root path =
     BW.withScope
         (\scope ->
-            Task.toResult <|
+            Task.run <|
                 (Task.eio Exit.TestBadDetails (Details.load style scope root)
                     |> Task.bind
                         (\details ->

--- a/src/Terminal/Uninstall.elm
+++ b/src/Terminal/Uninstall.elm
@@ -51,7 +51,7 @@ run args (Flags autoYes) =
                                     Task.pure (Err Exit.UninstallNoArgs)
 
                                 Uninstall pkg ->
-                                    Task.toResult
+                                    Task.run
                                         (Task.eio Exit.UninstallBadRegistry Solver.initEnv
                                             |> Task.bind
                                                 (\env ->

--- a/src/Text/PrettyPrint/ANSI/Leijen.elm
+++ b/src/Text/PrettyPrint/ANSI/Leijen.elm
@@ -38,7 +38,8 @@ module Text.PrettyPrint.ANSI.Leijen exposing
 import Pretty as P
 import Pretty.Renderer as PR
 import System.Console.Ansi as Ansi
-import System.IO as IO exposing (IO)
+import System.IO as IO
+import Task exposing (Task)
 
 
 type alias Doc =
@@ -52,7 +53,7 @@ type SimpleDoc
     | SSGR (List Ansi.SGR) SimpleDoc
 
 
-displayIO : IO.Handle -> SimpleDoc -> IO ()
+displayIO : IO.Handle -> SimpleDoc -> Task Never ()
 displayIO handle simpleDoc =
     IO.hPutStr handle (displayS simpleDoc "")
 

--- a/src/Utils/Task/Extra.elm
+++ b/src/Utils/Task/Extra.elm
@@ -22,7 +22,7 @@ import Task exposing (Task)
 toResult : Task x a -> Task Never (Result x a)
 toResult task =
     task
-        |> Task.andThen (\r -> Ok r |> Task.succeed)
+        |> Task.map (\r -> Ok r)
         |> Task.onError (\err -> Err err |> Task.succeed)
 
 

--- a/src/Utils/Task/Extra.elm
+++ b/src/Utils/Task/Extra.elm
@@ -1,13 +1,15 @@
-module Builder.Reporting.Task exposing
-    ( bind
+module Utils.Task.Extra exposing
+    ( apply
+    , bind
     , eio
     , fmap
     , io
     , mapError
+    , mapM
     , mio
     , pure
-    , run
     , throw
+    , toResult
     , void
     )
 
@@ -18,21 +20,21 @@ import Task exposing (Task)
 -- TASKS
 
 
-run : Task x a -> Task Never (Result x a)
-run task =
+toResult : Task x a -> Task Never (Result x a)
+toResult task =
     task
         |> Task.andThen (\r -> Ok r |> Task.succeed)
         |> Task.onError (\err -> Err err |> Task.succeed)
 
 
 throw : x -> Task x a
-throw x =
-    Task.fail x
+throw =
+    Task.fail
 
 
 mapError : (x -> y) -> Task x a -> Task y a
-mapError func task =
-    Task.mapError func task
+mapError =
+    Task.mapError
 
 
 
@@ -101,3 +103,8 @@ fmap =
 bind : (a -> Task x b) -> Task x a -> Task x b
 bind =
     Task.andThen
+
+
+mapM : (a -> Task x b) -> List a -> Task x (List b)
+mapM f =
+    List.map f >> Task.sequence

--- a/src/Utils/Task/Extra.elm
+++ b/src/Utils/Task/Extra.elm
@@ -7,8 +7,8 @@ module Utils.Task.Extra exposing
     , mapM
     , mio
     , pure
+    , run
     , throw
-    , toResult
     , void
     )
 
@@ -19,11 +19,11 @@ import Task exposing (Task)
 -- TASKS
 
 
-toResult : Task x a -> Task Never (Result x a)
-toResult task =
+run : Task x a -> Task Never (Result x a)
+run task =
     task
-        |> Task.map (\r -> Ok r)
-        |> Task.onError (\err -> Err err |> Task.succeed)
+        |> Task.map Ok
+        |> Task.onError (Err >> Task.succeed)
 
 
 throw : x -> Task x a

--- a/src/Utils/Task/Extra.elm
+++ b/src/Utils/Task/Extra.elm
@@ -4,7 +4,6 @@ module Utils.Task.Extra exposing
     , eio
     , fmap
     , io
-    , mapError
     , mapM
     , mio
     , pure
@@ -30,11 +29,6 @@ toResult task =
 throw : x -> Task x a
 throw =
     Task.fail
-
-
-mapError : (x -> y) -> Task x a -> Task y a
-mapError =
-    Task.mapError
 
 
 


### PR DESCRIPTION
I have replace all aliases onto the name `Task` with just the bare Elm `Task x a`. So no more `IO a`, or `Install.Task a` or other specialized versions of Task.

`Reporting.Task` was unnecessarily complicated by using `Result`, when `Task` already has space in its constructors for managing errors.

All `Task` monad helper code was moved into `Utils.Task.Extra`.

By doing this, it is much more obvious to work with Tasks, and see how they flow accross the whole project in a more unified way. Tasks are central to this project as it does a lot of IO. It is now simpler to do things like writing a debug IO task for example, that can be used in any Task context within the project.