### PR TITLE
Turns crashing into an IO operation wherever it happens within an IO context.

### DIFF
--- a/src/Browser/Main.elm
+++ b/src/Browser/Main.elm
@@ -69,12 +69,12 @@ app =
 
 getArgs : Task Never Args
 getArgs =
-    Impure.task "getArgs" [] Impure.EmptyBody (Impure.DecoderResolver argsDecoder)
+    Impure.task IO.crash "getArgs" [] Impure.EmptyBody (Impure.DecoderResolver argsDecoder)
 
 
 exitWithResponse : Encode.Value -> Task Never a
 exitWithResponse value =
-    Impure.task "exitWithResponse" [] (Impure.JsonBody value) Impure.Crash
+    Impure.task IO.crash "exitWithResponse" [] (Impure.JsonBody value) Impure.NoReturn
 
 
 

--- a/src/Builder/File.elm
+++ b/src/Builder/File.elm
@@ -107,12 +107,12 @@ writeUtf8 =
 
 readUtf8 : FilePath -> Task Never String
 readUtf8 path =
-    Impure.task "read" [] (Impure.StringBody path) (Impure.StringResolver identity)
+    Impure.task IO.crash "read" [] (Impure.StringBody path) (Impure.StringResolver identity)
 
 
 readStdin : Task Never String
 readStdin =
-    Impure.task "readStdin" [] Impure.EmptyBody (Impure.StringResolver identity)
+    Impure.task IO.crash "readStdin" [] Impure.EmptyBody (Impure.StringResolver identity)
 
 
 

--- a/src/Builder/Http.elm
+++ b/src/Builder/Http.elm
@@ -27,6 +27,7 @@ import Compiler.Elm.Version as V
 import Http
 import Json.Decode as Decode
 import Json.Encode as Encode
+import System.IO as IO
 import Task exposing (Task)
 import Url.Builder
 import Utils.Bytes.Decode as BD
@@ -109,7 +110,8 @@ post =
 
 fetch : String -> Manager -> String -> List Header -> (Error -> e) -> (String -> Task Never (Result e a)) -> Task Never (Result e a)
 fetch method _ url headers _ onSuccess =
-    Impure.customTask method
+    Impure.customTask IO.crash
+        method
         url
         (List.map (\( a, b ) -> Http.header a b) (addDefaultHeaders headers))
         Impure.EmptyBody
@@ -161,7 +163,8 @@ shaToChars =
 
 getArchive : Manager -> String -> (Error -> e) -> e -> (( Sha, Zip.Archive ) -> Task Never (Result e a)) -> Task Never (Result e a)
 getArchive _ url _ _ onSuccess =
-    Impure.task "getArchive"
+    Impure.task IO.crash
+        "getArchive"
         []
         (Impure.StringBody url)
         (Impure.DecoderResolver
@@ -192,7 +195,8 @@ type MultiPart
 
 upload : Manager -> String -> List MultiPart -> Task Never (Result Error ())
 upload _ url parts =
-    Impure.task "httpUpload"
+    Impure.task IO.crash
+        "httpUpload"
         []
         (Impure.JsonBody
             (Encode.object

--- a/src/Compiler/Reporting/Error.elm
+++ b/src/Compiler/Reporting/Error.elm
@@ -13,7 +13,7 @@ import Compiler.Data.OneOrMore as OneOrMore exposing (OneOrMore)
 import Compiler.Elm.ModuleName as ModuleName
 import Compiler.Json.Encode as E
 import Compiler.Nitpick.PatternMatches as P
-import Compiler.Reporting.Annotation as A
+import Compiler.Reporting.Annotation as A exposing (zero)
 import Compiler.Reporting.Doc as D
 import Compiler.Reporting.Error.Canonicalize as Canonicalize
 import Compiler.Reporting.Error.Docs as Docs
@@ -25,6 +25,7 @@ import Compiler.Reporting.Error.Type as Type
 import Compiler.Reporting.Render.Code as Code
 import Compiler.Reporting.Render.Type.Localizer as L
 import Compiler.Reporting.Report as Report
+import Text.PrettyPrint.ANSI.Leijen exposing (empty)
 import Time
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE

--- a/src/Compiler/Reporting/Error.elm
+++ b/src/Compiler/Reporting/Error.elm
@@ -13,7 +13,7 @@ import Compiler.Data.OneOrMore as OneOrMore exposing (OneOrMore)
 import Compiler.Elm.ModuleName as ModuleName
 import Compiler.Json.Encode as E
 import Compiler.Nitpick.PatternMatches as P
-import Compiler.Reporting.Annotation as A exposing (zero)
+import Compiler.Reporting.Annotation as A
 import Compiler.Reporting.Doc as D
 import Compiler.Reporting.Error.Canonicalize as Canonicalize
 import Compiler.Reporting.Error.Docs as Docs
@@ -25,7 +25,6 @@ import Compiler.Reporting.Error.Type as Type
 import Compiler.Reporting.Render.Code as Code
 import Compiler.Reporting.Render.Type.Localizer as L
 import Compiler.Reporting.Report as Report
-import Text.PrettyPrint.ANSI.Leijen exposing (empty)
 import Time
 import Utils.Bytes.Decode as BD
 import Utils.Bytes.Encode as BE

--- a/src/Compiler/Type/Solve.elm
+++ b/src/Compiler/Type/Solve.elm
@@ -19,7 +19,6 @@ import Data.Map as Dict exposing (Dict)
 import Data.Vector as Vector
 import Data.Vector.Mutable as MVector
 import System.TypeCheck.IO as IO exposing (Content, Descriptor(..), IO, Mark, Variable)
-import Utils.Crash exposing (crash)
 import Utils.Main as Utils
 
 
@@ -349,14 +348,14 @@ isGeneric var =
                     Type.toErrorType var
                         |> IO.bind
                             (\tipe ->
-                                crash <|
-                                    "You ran into a compiler bug. Here are some details for the developers:\n\n"
-                                        ++ "    "
-                                        ++ Doc.toString (ET.toDoc L.empty RT.None tipe)
-                                        ++ " [rank = "
-                                        ++ String.fromInt rank
-                                        ++ "]\n\n"
-                                        ++ "Please create an <http://sscce.org/> and then report it\nat <https://github.com/elm/compiler/issues>\n\n"
+                                "You ran into a compiler bug. Here are some details for the developers:\n\n"
+                                    ++ "    "
+                                    ++ Doc.toString (ET.toDoc L.empty RT.None tipe)
+                                    ++ " [rank = "
+                                    ++ String.fromInt rank
+                                    ++ "]\n\n"
+                                    ++ "Please create an <http://sscce.org/> and then report it\nat <https://github.com/elm/compiler/issues>\n\n"
+                                    |> IO.throw
                             )
             )
 

--- a/src/Compiler/Type/UnionFind.elm
+++ b/src/Compiler/Type/UnionFind.elm
@@ -24,7 +24,6 @@ module Compiler.Type.UnionFind exposing
 
 import Data.IORef as IORef exposing (IORef(..))
 import System.TypeCheck.IO as IO exposing (Descriptor, IO)
-import Utils.Crash exposing (crash)
 
 
 
@@ -187,7 +186,7 @@ union p1 p2 newDesc =
                                                                         )
 
                                                         _ ->
-                                                            crash "Unexpected pattern"
+                                                            IO.throw "Unexpected pattern"
                                                 )
                                     )
                         )

--- a/src/Control/Monad/State/Strict.elm
+++ b/src/Control/Monad/State/Strict.elm
@@ -70,7 +70,8 @@ pure value =
 get : StateT s IO.ReplState
 get =
     liftIO
-        (Impure.task "getStateT"
+        (Impure.task IO.crash
+            "getStateT"
             []
             Impure.EmptyBody
             (Impure.DecoderResolver
@@ -85,7 +86,8 @@ get =
 
 put : IO.ReplState -> Task Never ()
 put (IO.ReplState imports types decls) =
-    Impure.task "putStateT"
+    Impure.task IO.crash
+        "putStateT"
         []
         (Impure.JsonBody
             (Encode.object

--- a/src/Control/Monad/State/TypeCheck/Strict.elm
+++ b/src/Control/Monad/State/TypeCheck/Strict.elm
@@ -9,6 +9,7 @@ module Control.Monad.State.TypeCheck.Strict exposing
     , modify
     , pure
     , runStateT
+    , throw
     , traverseList
     , traverseMap
     , traverseMaybe
@@ -88,6 +89,11 @@ bind func (StateT arg) =
 pure : a -> StateT s a
 pure value =
     StateT (\s -> IO.pure ( value, s ))
+
+
+throw : String -> StateT s a
+throw msg =
+    StateT (\_ -> IO.throw msg)
 
 
 gets : (s -> a) -> StateT s a

--- a/src/Data/IORef.elm
+++ b/src/Data/IORef.elm
@@ -18,7 +18,6 @@ module Data.IORef exposing
 
 import Array exposing (Array)
 import System.TypeCheck.IO as IO exposing (IO)
-import Utils.Crash exposing (crash)
 
 
 type IORef a
@@ -27,22 +26,22 @@ type IORef a
 
 newIORefWeight : Int -> IO (IORef Int)
 newIORefWeight value =
-    \s -> ( { s | ioRefsWeight = Array.push value s.ioRefsWeight }, IORef (Array.length s.ioRefsWeight) )
+    \s -> Ok ( { s | ioRefsWeight = Array.push value s.ioRefsWeight }, IORef (Array.length s.ioRefsWeight) )
 
 
 newIORefPointInfo : IO.PointInfo -> IO (IORef IO.PointInfo)
 newIORefPointInfo value =
-    \s -> ( { s | ioRefsPointInfo = Array.push value s.ioRefsPointInfo }, IORef (Array.length s.ioRefsPointInfo) )
+    \s -> Ok ( { s | ioRefsPointInfo = Array.push value s.ioRefsPointInfo }, IORef (Array.length s.ioRefsPointInfo) )
 
 
 newIORefDescriptor : IO.Descriptor -> IO (IORef IO.Descriptor)
 newIORefDescriptor value =
-    \s -> ( { s | ioRefsDescriptor = Array.push value s.ioRefsDescriptor }, IORef (Array.length s.ioRefsDescriptor) )
+    \s -> Ok ( { s | ioRefsDescriptor = Array.push value s.ioRefsDescriptor }, IORef (Array.length s.ioRefsDescriptor) )
 
 
 newIORefMVector : Array (Maybe (List IO.Variable)) -> IO (IORef (Array (Maybe (List IO.Variable))))
 newIORefMVector value =
-    \s -> ( { s | ioRefsMVector = Array.push value s.ioRefsMVector }, IORef (Array.length s.ioRefsMVector) )
+    \s -> Ok ( { s | ioRefsMVector = Array.push value s.ioRefsMVector }, IORef (Array.length s.ioRefsMVector) )
 
 
 readIORefWeight : IORef Int -> IO Int
@@ -50,10 +49,10 @@ readIORefWeight (IORef ref) =
     \s ->
         case Array.get ref s.ioRefsWeight of
             Just value ->
-                ( s, value )
+                Ok ( s, value )
 
             Nothing ->
-                crash "Data.IORef.readIORefWeight: could not find entry"
+                IO.fatal "Data.IORef.readIORefWeight: could not find entry"
 
 
 readIORefPointInfo : IORef IO.PointInfo -> IO IO.PointInfo
@@ -61,10 +60,10 @@ readIORefPointInfo (IORef ref) =
     \s ->
         case Array.get ref s.ioRefsPointInfo of
             Just value ->
-                ( s, value )
+                Ok ( s, value )
 
             Nothing ->
-                crash "Data.IORef.readIORefPointInfo: could not find entry"
+                IO.fatal "Data.IORef.readIORefPointInfo: could not find entry"
 
 
 readIORefDescriptor : IORef IO.Descriptor -> IO IO.Descriptor
@@ -72,10 +71,10 @@ readIORefDescriptor (IORef ref) =
     \s ->
         case Array.get ref s.ioRefsDescriptor of
             Just value ->
-                ( s, value )
+                Ok ( s, value )
 
             Nothing ->
-                crash "Data.IORef.readIORefDescriptor: could not find entry"
+                IO.fatal "Data.IORef.readIORefDescriptor: could not find entry"
 
 
 readIORefMVector : IORef (Array (Maybe (List IO.Variable))) -> IO (Array (Maybe (List IO.Variable)))
@@ -83,30 +82,30 @@ readIORefMVector (IORef ref) =
     \s ->
         case Array.get ref s.ioRefsMVector of
             Just value ->
-                ( s, value )
+                Ok ( s, value )
 
             Nothing ->
-                crash "Data.IORef.readIORefMVector: could not find entry"
+                IO.fatal "Data.IORef.readIORefMVector: could not find entry"
 
 
 writeIORefWeight : IORef Int -> Int -> IO ()
 writeIORefWeight (IORef ref) value =
-    \s -> ( { s | ioRefsWeight = Array.set ref value s.ioRefsWeight }, () )
+    \s -> Ok ( { s | ioRefsWeight = Array.set ref value s.ioRefsWeight }, () )
 
 
 writeIORefPointInfo : IORef IO.PointInfo -> IO.PointInfo -> IO ()
 writeIORefPointInfo (IORef ref) value =
-    \s -> ( { s | ioRefsPointInfo = Array.set ref value s.ioRefsPointInfo }, () )
+    \s -> Ok ( { s | ioRefsPointInfo = Array.set ref value s.ioRefsPointInfo }, () )
 
 
 writeIORefDescriptor : IORef IO.Descriptor -> IO.Descriptor -> IO ()
 writeIORefDescriptor (IORef ref) value =
-    \s -> ( { s | ioRefsDescriptor = Array.set ref value s.ioRefsDescriptor }, () )
+    \s -> Ok ( { s | ioRefsDescriptor = Array.set ref value s.ioRefsDescriptor }, () )
 
 
 writeIORefMVector : IORef (Array (Maybe (List IO.Variable))) -> Array (Maybe (List IO.Variable)) -> IO ()
 writeIORefMVector (IORef ref) value =
-    \s -> ( { s | ioRefsMVector = Array.set ref value s.ioRefsMVector }, () )
+    \s -> Ok ( { s | ioRefsMVector = Array.set ref value s.ioRefsMVector }, () )
 
 
 modifyIORefDescriptor : IORef IO.Descriptor -> (IO.Descriptor -> IO.Descriptor) -> IO ()

--- a/src/Data/Vector.elm
+++ b/src/Data/Vector.elm
@@ -9,23 +9,22 @@ module Data.Vector exposing
 import Array exposing (Array)
 import Data.IORef as IORef exposing (IORef)
 import System.TypeCheck.IO as IO exposing (IO, Variable)
-import Utils.Crash exposing (crash)
 
 
 unsafeLast : IORef (Array (Maybe (List Variable))) -> IO (List Variable)
 unsafeLast ioRef =
     IORef.readIORefMVector ioRef
-        |> IO.fmap
+        |> IO.bind
             (\array ->
                 case Array.get (Array.length array - 1) array of
                     Just (Just value) ->
-                        value
+                        value |> IO.pure
 
                     Just Nothing ->
-                        crash "Data.Vector.unsafeLast: invalid value"
+                        IO.throw "Data.Vector.unsafeLast: invalid value"
 
                     Nothing ->
-                        crash "Data.Vector.unsafeLast: empty array"
+                        IO.throw "Data.Vector.unsafeLast: empty array"
             )
 
 

--- a/src/Data/Vector/Mutable.elm
+++ b/src/Data/Vector/Mutable.elm
@@ -11,7 +11,6 @@ import Array exposing (Array)
 import Array.Extra as Array
 import Data.IORef as IORef exposing (IORef)
 import System.TypeCheck.IO as IO exposing (IO, Variable)
-import Utils.Crash exposing (crash)
 
 
 length : IORef (Array (Maybe (List Variable))) -> IO Int
@@ -39,17 +38,17 @@ grow ioRef length_ =
 read : IORef (Array (Maybe (List Variable))) -> Int -> IO (List Variable)
 read ioRef i =
     IORef.readIORefMVector ioRef
-        |> IO.fmap
+        |> IO.bind
             (\array ->
                 case Array.get i array of
                     Just (Just value) ->
-                        value
+                        value |> IO.pure
 
                     Just Nothing ->
-                        crash "Data.Vector.read: invalid value"
+                        IO.throw "Data.Vector.read: invalid value"
 
                     Nothing ->
-                        crash "Data.Vector.read: could not find entry"
+                        IO.throw "Data.Vector.read: could not find entry"
             )
 
 

--- a/src/Node/Main.elm
+++ b/src/Node/Main.elm
@@ -32,12 +32,12 @@ app =
 
 getArgs : Task Never Args
 getArgs =
-    Impure.task "getArgs" [] Impure.EmptyBody (Impure.DecoderResolver argsDecoder)
+    Impure.task IO.crash "getArgs" [] Impure.EmptyBody (Impure.DecoderResolver argsDecoder)
 
 
 exitWithResponse : Encode.Value -> Task Never a
 exitWithResponse value =
-    Impure.task "exitWithResponse" [] (Impure.JsonBody value) Impure.Crash
+    Impure.task IO.crash "exitWithResponse" [] (Impure.JsonBody value) Impure.NoReturn
 
 
 

--- a/src/System/Exit.elm
+++ b/src/System/Exit.elm
@@ -5,6 +5,7 @@ module System.Exit exposing
     , exitWith
     )
 
+import System.IO as IO
 import Task exposing (Task)
 import Utils.Impure as Impure
 
@@ -26,10 +27,12 @@ exitWith exitCode =
                 ExitFailure int ->
                     int
     in
-    Impure.task "exitWith"
+    Impure.task
+        IO.crash
+        "exitWith"
         []
         (Impure.StringBody (String.fromInt code))
-        Impure.Crash
+        Impure.NoReturn
 
 
 exitFailure : Task Never a

--- a/src/System/IO.elm
+++ b/src/System/IO.elm
@@ -76,6 +76,8 @@ module System.IO exposing
 
 # Go Bang, But Nicely!
 
+@docs crash
+
 -}
 
 import Dict exposing (Dict)

--- a/src/System/Process.elm
+++ b/src/System/Process.elm
@@ -51,7 +51,8 @@ proc cmd args =
 
 withCreateProcess : CreateProcess -> (Maybe IO.Handle -> Maybe IO.Handle -> Maybe IO.Handle -> ProcessHandle -> Task Never Exit.ExitCode) -> Task Never Exit.ExitCode
 withCreateProcess createProcess f =
-    Impure.task "withCreateProcess"
+    Impure.task IO.crash
+        "withCreateProcess"
         []
         (Impure.JsonBody
             (Encode.object
@@ -123,7 +124,8 @@ withCreateProcess createProcess f =
 
 waitForProcess : ProcessHandle -> Task Never Exit.ExitCode
 waitForProcess (ProcessHandle ph) =
-    Impure.task "waitForProcess"
+    Impure.task IO.crash
+        "waitForProcess"
         []
         (Impure.StringBody (String.fromInt ph))
         (Impure.DecoderResolver

--- a/src/System/TypeCheck/IO.elm
+++ b/src/System/TypeCheck/IO.elm
@@ -39,6 +39,11 @@ module System.TypeCheck.IO exposing
 
 @docs Canonical
 
+
+# Errors and mechanism to throw them
+
+@docs Error, errorToString, fatal, throw
+
 -}
 
 import Array exposing (Array)
@@ -131,7 +136,7 @@ apply ma mf =
 fmap : (a -> b) -> IO a -> IO b
 fmap fn ma s0 =
     ma s0
-        |> Result.andThen (\( s1, a ) -> Ok ( s1, fn a ))
+        |> Result.map (\( s1, a ) -> ( s1, fn a ))
 
 
 bind : (a -> IO b) -> IO a -> IO b

--- a/src/Terminal/Main.elm
+++ b/src/Terminal/Main.elm
@@ -28,10 +28,11 @@ main =
         (app
             |> Task.bind
                 (\() ->
-                    Impure.task "exitWith"
+                    Impure.task IO.crash
+                        "exitWith"
                         []
                         (Impure.StringBody "0")
-                        Impure.Crash
+                        Impure.NoReturn
                 )
         )
 

--- a/src/Terminal/Repl.elm
+++ b/src/Terminal/Repl.elm
@@ -46,7 +46,6 @@ import System.Exit as Exit
 import System.IO as IO
 import System.Process as Process
 import Task exposing (Task)
-import Utils.Crash exposing (crash)
 import Utils.Main as Utils exposing (FilePath)
 import Utils.Task.Extra as Task
 
@@ -646,7 +645,7 @@ interpret interpreter javascript =
                         |> Task.bind (\_ -> Process.waitForProcess handle)
 
                 Nothing ->
-                    crash "not implemented"
+                    IO.crash "not implemented"
 
 
 

--- a/src/Utils/Main.elm
+++ b/src/Utils/Main.elm
@@ -754,7 +754,8 @@ lockWithFileLock path mode ioFunc =
 
 lockFile : FilePath -> Task Never ()
 lockFile path =
-    Impure.task "lockFile"
+    Impure.task IO.crash
+        "lockFile"
         []
         (Impure.StringBody path)
         (Impure.Always ())
@@ -762,7 +763,8 @@ lockFile path =
 
 unlockFile : FilePath -> Task Never ()
 unlockFile path =
-    Impure.task "unlockFile"
+    Impure.task IO.crash
+        "unlockFile"
         []
         (Impure.StringBody path)
         (Impure.Always ())
@@ -774,7 +776,8 @@ unlockFile path =
 
 dirDoesFileExist : FilePath -> Task Never Bool
 dirDoesFileExist filename =
-    Impure.task "dirDoesFileExist"
+    Impure.task IO.crash
+        "dirDoesFileExist"
         []
         (Impure.StringBody filename)
         (Impure.DecoderResolver Decode.bool)
@@ -782,7 +785,8 @@ dirDoesFileExist filename =
 
 dirFindExecutable : FilePath -> Task Never (Maybe FilePath)
 dirFindExecutable filename =
-    Impure.task "dirFindExecutable"
+    Impure.task IO.crash
+        "dirFindExecutable"
         []
         (Impure.StringBody filename)
         (Impure.DecoderResolver (Decode.maybe Decode.string))
@@ -790,7 +794,8 @@ dirFindExecutable filename =
 
 dirCreateDirectoryIfMissing : Bool -> FilePath -> Task Never ()
 dirCreateDirectoryIfMissing createParents filename =
-    Impure.task "dirCreateDirectoryIfMissing"
+    Impure.task IO.crash
+        "dirCreateDirectoryIfMissing"
         []
         (Impure.JsonBody
             (Encode.object
@@ -804,7 +809,8 @@ dirCreateDirectoryIfMissing createParents filename =
 
 dirGetCurrentDirectory : Task Never String
 dirGetCurrentDirectory =
-    Impure.task "dirGetCurrentDirectory"
+    Impure.task IO.crash
+        "dirGetCurrentDirectory"
         []
         Impure.EmptyBody
         (Impure.StringResolver identity)
@@ -812,7 +818,8 @@ dirGetCurrentDirectory =
 
 dirGetAppUserDataDirectory : FilePath -> Task Never FilePath
 dirGetAppUserDataDirectory filename =
-    Impure.task "dirGetAppUserDataDirectory"
+    Impure.task IO.crash
+        "dirGetAppUserDataDirectory"
         []
         (Impure.StringBody filename)
         (Impure.StringResolver identity)
@@ -820,7 +827,8 @@ dirGetAppUserDataDirectory filename =
 
 dirGetModificationTime : FilePath -> Task Never Time.Posix
 dirGetModificationTime filename =
-    Impure.task "dirGetModificationTime"
+    Impure.task IO.crash
+        "dirGetModificationTime"
         []
         (Impure.StringBody filename)
         (Impure.DecoderResolver (Decode.map Time.millisToPosix Decode.int))
@@ -828,7 +836,8 @@ dirGetModificationTime filename =
 
 dirRemoveFile : FilePath -> Task Never ()
 dirRemoveFile path =
-    Impure.task "dirRemoveFile"
+    Impure.task IO.crash
+        "dirRemoveFile"
         []
         (Impure.StringBody path)
         (Impure.Always ())
@@ -836,7 +845,8 @@ dirRemoveFile path =
 
 dirRemoveDirectoryRecursive : FilePath -> Task Never ()
 dirRemoveDirectoryRecursive path =
-    Impure.task "dirRemoveDirectoryRecursive"
+    Impure.task IO.crash
+        "dirRemoveDirectoryRecursive"
         []
         (Impure.StringBody path)
         (Impure.Always ())
@@ -844,7 +854,8 @@ dirRemoveDirectoryRecursive path =
 
 dirDoesDirectoryExist : FilePath -> Task Never Bool
 dirDoesDirectoryExist path =
-    Impure.task "dirDoesDirectoryExist"
+    Impure.task IO.crash
+        "dirDoesDirectoryExist"
         []
         (Impure.StringBody path)
         (Impure.DecoderResolver Decode.bool)
@@ -852,7 +863,8 @@ dirDoesDirectoryExist path =
 
 dirCanonicalizePath : FilePath -> Task Never FilePath
 dirCanonicalizePath path =
-    Impure.task "dirCanonicalizePath"
+    Impure.task IO.crash
+        "dirCanonicalizePath"
         []
         (Impure.StringBody path)
         (Impure.StringResolver identity)
@@ -864,12 +876,14 @@ dirWithCurrentDirectory dir action =
         |> Task.bind
             (\currentDir ->
                 bracket_
-                    (Impure.task "dirWithCurrentDirectory"
+                    (Impure.task IO.crash
+                        "dirWithCurrentDirectory"
                         []
                         (Impure.StringBody dir)
                         (Impure.Always ())
                     )
-                    (Impure.task "dirWithCurrentDirectory"
+                    (Impure.task IO.crash
+                        "dirWithCurrentDirectory"
                         []
                         (Impure.StringBody currentDir)
                         (Impure.Always ())
@@ -880,7 +894,8 @@ dirWithCurrentDirectory dir action =
 
 dirListDirectory : FilePath -> Task Never (List FilePath)
 dirListDirectory path =
-    Impure.task "dirListDirectory"
+    Impure.task IO.crash
+        "dirListDirectory"
         []
         (Impure.StringBody path)
         (Impure.DecoderResolver (Decode.list Decode.string))
@@ -892,7 +907,8 @@ dirListDirectory path =
 
 envLookupEnv : String -> Task Never (Maybe String)
 envLookupEnv name =
-    Impure.task "envLookupEnv"
+    Impure.task IO.crash
+        "envLookupEnv"
         []
         (Impure.StringBody name)
         (Impure.DecoderResolver (Decode.maybe Decode.string))
@@ -905,7 +921,8 @@ envGetProgName =
 
 envGetArgs : Task Never (List String)
 envGetArgs =
-    Impure.task "envGetArgs"
+    Impure.task IO.crash
+        "envGetArgs"
         []
         Impure.EmptyBody
         (Impure.DecoderResolver (Decode.list Decode.string))
@@ -1035,7 +1052,8 @@ newMVar toEncoder value =
 
 readMVar : BD.Decoder a -> MVar a -> Task Never a
 readMVar decoder (MVar ref) =
-    Impure.task "readMVar"
+    Impure.task IO.crash
+        "readMVar"
         []
         (Impure.StringBody (String.fromInt ref))
         (Impure.BytesResolver decoder)
@@ -1054,7 +1072,8 @@ modifyMVar decoder toEncoder m io =
 
 takeMVar : BD.Decoder a -> MVar a -> Task Never a
 takeMVar decoder (MVar ref) =
-    Impure.task "takeMVar"
+    Impure.task IO.crash
+        "takeMVar"
         []
         (Impure.StringBody (String.fromInt ref))
         (Impure.BytesResolver decoder)
@@ -1062,7 +1081,8 @@ takeMVar decoder (MVar ref) =
 
 putMVar : (a -> BE.Encoder) -> MVar a -> a -> Task Never ()
 putMVar encoder (MVar ref) value =
-    Impure.task "putMVar"
+    Impure.task IO.crash
+        "putMVar"
         [ Http.header "id" (String.fromInt ref) ]
         (Impure.BytesBody (encoder value))
         (Impure.Always ())
@@ -1070,7 +1090,8 @@ putMVar encoder (MVar ref) value =
 
 newEmptyMVar : Task Never (MVar a)
 newEmptyMVar =
-    Impure.task "newEmptyMVar"
+    Impure.task IO.crash
+        "newEmptyMVar"
         []
         Impure.EmptyBody
         (Impure.DecoderResolver (Decode.map MVar Decode.int))
@@ -1151,7 +1172,8 @@ builderHPutBuilder =
 
 binaryDecodeFileOrFail : BD.Decoder a -> FilePath -> Task Never (Result ( Int, String ) a)
 binaryDecodeFileOrFail decoder filename =
-    Impure.task "binaryDecodeFileOrFail"
+    Impure.task IO.crash
+        "binaryDecodeFileOrFail"
         []
         (Impure.StringBody filename)
         (Impure.BytesResolver (BD.map Ok decoder))
@@ -1159,7 +1181,8 @@ binaryDecodeFileOrFail decoder filename =
 
 binaryEncodeFile : (a -> BE.Encoder) -> FilePath -> a -> Task Never ()
 binaryEncodeFile toEncoder path value =
-    Impure.task "write"
+    Impure.task IO.crash
+        "write"
         [ Http.header "path" path ]
         (Impure.BytesBody (toEncoder value))
         (Impure.Always ())
@@ -1207,7 +1230,8 @@ replCompleteWord _ _ _ =
 
 replGetInputLine : String -> ReplInputT (Maybe String)
 replGetInputLine prompt =
-    Impure.task "replGetInputLine"
+    Impure.task IO.crash
+        "replGetInputLine"
         []
         (Impure.StringBody prompt)
         (Impure.DecoderResolver (Decode.maybe Decode.string))
@@ -1224,7 +1248,8 @@ replGetInputLineWithInitial prompt ( left, right ) =
 
 nodeGetDirname : Task Never String
 nodeGetDirname =
-    Impure.task "nodeGetDirname"
+    Impure.task IO.crash
+        "nodeGetDirname"
         []
         Impure.EmptyBody
         (Impure.StringResolver identity)
@@ -1232,7 +1257,8 @@ nodeGetDirname =
 
 nodeMathRandom : Task Never Float
 nodeMathRandom =
-    Impure.task "nodeMathRandom"
+    Impure.task IO.crash
+        "nodeMathRandom"
         []
         Impure.EmptyBody
         (Impure.DecoderResolver Decode.float)


### PR DESCRIPTION
`Crash.crash` just infinite loops.

`IO.crash` will write stderr then call system.exit(-1), and is a `Task Never a`.

Wherever it was possible as code is running within an IO `Task Never a` context, the IO.crash function has been used. This ensures that many of the fatal crash errors the compiler can hit will be printed to stderr and the compilation will exit with a POSIX error code.