### PR TITLE
Replacing the infinite looping Crash.crash with log and exit.

### DIFF
--- a/assets/some-application/src/Rank2TypecheckBug.elm
+++ b/assets/some-application/src/Rank2TypecheckBug.elm
@@ -1,0 +1,10 @@
+module Rank2TypecheckBug exposing (..)
+
+
+f x =
+    let
+        g : (a -> ()) -> ()
+        g h =
+            h x
+    in
+    x

--- a/scripts/replace-bytes-read-string.js
+++ b/scripts/replace-bytes-read-string.js
@@ -14,6 +14,23 @@ const path = argv[0];
 
 const data = fs
     .readFileSync(path, { encoding: 'utf8', flag: 'r' })
+    .replace(`var $author$project$Utils$Crash$crash = function (str) {
+\tcrash:
+\twhile (true) {
+\t\tvar $temp$str = str;
+\t\tstr = $temp$str;
+\t\tcontinue crash;
+\t}
+};`,`var $author$project$Utils$Crash$crash = function (str) {
+\tprocess.stderr.write(str);
+\ttry {
+\t\tthrow new Error();
+\t} catch(e) {
+\t\tprocess.stderr.write(e.stack);
+\t\tprocess.stderr.write("\\\\n");
+\t}
+\tprocess.exit(-1);
+};`)
     .replace(`var _Bytes_read_string = F3(function(len, bytes, offset)
 {
 	var string = '';


### PR DESCRIPTION
Replaces the Crash.crash function with one that logs to stderr and exits with -1.

